### PR TITLE
Add a phantom write test

### DIFF
--- a/scalardb-test/phantom-write-config.toml
+++ b/scalardb-test/phantom-write-config.toml
@@ -1,0 +1,40 @@
+[modules]
+  [modules.preprocessor]
+    name = "kelpie.scalardb.sensor.SensorPreparer"
+    path = "build/libs/scalardb-test-all.jar"
+  [modules.processor]
+    name = "kelpie.scalardb.sensor.SensorProcessor"
+    path = "build/libs/scalardb-test-all.jar"
+  [modules.postprocessor]
+    name = "kelpie.scalardb.sensor.SensorChecker"
+    path = "build/libs/scalardb-test-all.jar"
+  [[modules.injectors]]
+    name = "kelpie.scalardb.injector.CassandraKiller"
+    path = "build/libs/scalardb-test-all.jar"
+
+[common]
+  concurrency = 5
+  run_for_sec = 900
+  ramp_for_sec = 0
+
+[stats]
+  realtime_report_enabled = false
+
+[test_config]
+  is_verification = true
+  is_serializable = true
+  is_extra_read = true
+  num_devices = 5
+
+[storage_config]
+  contact_points = "localhost"
+  #username = "cassandra"
+  #password = "cassandra"
+  #storage = "cassandra"
+
+[killer_config]
+  ssh_user = "centos"
+  ssh_port = 22
+  ssh_private_key = "/home/centos/.ssh/private_key"
+  contact_points = "localhost"
+  max_kill_interval_sec = 300

--- a/scalardb-test/schema/tx_sensor.cql
+++ b/scalardb-test/schema/tx_sensor.cql
@@ -1,0 +1,29 @@
+DROP KEYSPACE IF EXISTS sensor;
+CREATE KEYSPACE IF NOT EXISTS sensor WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };
+DROP KEYSPACE IF EXISTS coordinator;
+CREATE KEYSPACE IF NOT EXISTS coordinator WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };
+
+CREATE TABLE IF NOT EXISTS sensor.tx_sensor (
+    timestamp int,
+    device_id int,
+    revision int,
+    before_revision int,
+    before_tx_committed_at bigint,
+    before_tx_id text,
+    before_tx_prepared_at bigint,
+    before_tx_state int,
+    before_tx_version int,
+    tx_committed_at bigint,
+    tx_id text,
+    tx_prepared_at bigint,
+    tx_state int,
+    tx_version int,
+    PRIMARY KEY (timestamp, device_id)
+) WITH compaction = { 'class' : 'LeveledCompactionStrategy' };
+
+CREATE TABLE IF NOT EXISTS coordinator.state (
+    tx_id text,
+    tx_state int,
+    tx_created_at bigint,
+    PRIMARY KEY (tx_id)
+);

--- a/scalardb-test/src/main/java/kelpie/scalardb/sensor/SensorChecker.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/sensor/SensorChecker.java
@@ -1,0 +1,86 @@
+package kelpie.scalardb.sensor;
+
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.exception.transaction.CrudException;
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.exception.PostProcessException;
+import com.scalar.kelpie.modules.PostProcessor;
+import io.github.resilience4j.retry.Retry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+import kelpie.scalardb.Common;
+
+public class SensorChecker extends PostProcessor {
+  private final DistributedTransactionManager manager;
+
+  public SensorChecker(Config config) {
+    super(config);
+    this.manager = SensorCommon.getTransactionManager(config);
+  }
+
+  @Override
+  public void execute() {
+    int startTimestamp = getIntFromPreviousState("start_timestamp");
+    int endTimestamp = getIntFromPreviousState("end_timestamp");
+
+    boolean isDuplicated = false;
+    for (int i = startTimestamp; i <= endTimestamp; i++) {
+      List<Result> results = readRecordsWithRetry(i);
+
+      boolean hasDuplicatedRevision = SensorCommon.hasDuplicatedRevision(results);
+      if (hasDuplicatedRevision) {
+        isDuplicated = true;
+        logError("There is a duplicated revision at " + i);
+      }
+    }
+
+    if (isDuplicated) {
+      logError("dupilication happened !");
+      throw new PostProcessException("Inconsistency happened!");
+    }
+  }
+
+  @Override
+  public void close() {}
+
+  private List<Result> readRecordsWithRetry(int timestamp) {
+    Retry retry = Common.getRetryWithExponentialBackoff("readRecords");
+    Supplier<List<Result>> decorated = Retry.decorateSupplier(retry, () -> readRecords(timestamp));
+
+    try {
+      return decorated.get();
+    } catch (Exception e) {
+      throw new RuntimeException("Reading records failed repeatedly", e);
+    }
+  }
+
+  private List<Result> readRecords(int timestamp) {
+    List<Result> results = new ArrayList<>();
+
+    DistributedTransaction transaction = manager.start();
+    Scan scan = SensorCommon.prepareScan(timestamp);
+    try {
+      results = transaction.scan(scan);
+    } catch (CrudException e) {
+      // for Retry
+      throw new RuntimeException("at least 1 record couldn't be read");
+    }
+
+    return results;
+  }
+
+  private int getIntFromPreviousState(String name) {
+    int value = 0;
+    if (getPreviousState().isNull(name)) {
+      logWarn("There is no " + name + " since you use `--only-post`");
+    } else {
+      value = getPreviousState().getInt(name);
+    }
+
+    return value;
+  }
+}

--- a/scalardb-test/src/main/java/kelpie/scalardb/sensor/SensorCommon.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/sensor/SensorCommon.java
@@ -1,0 +1,62 @@
+package kelpie.scalardb.sensor;
+
+import com.scalar.db.api.Consistency;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.io.IntValue;
+import com.scalar.db.transaction.consensuscommit.TransactionResult;
+import com.scalar.db.io.Key;
+import com.scalar.kelpie.config.Config;
+import java.util.HashSet;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.stream.IntStream;
+import kelpie.scalardb.Common;
+
+public class SensorCommon {
+  private static final String KEYSPACE = "sensor";
+  private static final String TABLE = "tx_sensor";
+  private static final String TIMESTAMP = "timestamp";
+  private static final String DEVICE_ID = "device_id";
+  private static final String REVISION = "revision";
+
+  public static DistributedTransactionManager getTransactionManager(Config config) {
+    return Common.getTransactionManager(config, KEYSPACE, TABLE);
+  }
+
+  public static Scan prepareScan(int timestamp) {
+    Key partitionKey = new Key(new IntValue(TIMESTAMP, timestamp));
+
+    return new Scan(partitionKey)
+        .withOrdering(new Scan.Ordering(DEVICE_ID, Scan.Ordering.Order.ASC))
+        .withConsistency(Consistency.LINEARIZABLE);
+  }
+
+  public static Put preparePut(int timestamp, int deviceId, int revision) {
+    Key partitionKey = new Key(new IntValue(TIMESTAMP, timestamp));
+    Key clusteringKey = new Key(new IntValue(DEVICE_ID, deviceId));
+    return new Put(partitionKey, clusteringKey)
+        .withConsistency(Consistency.LINEARIZABLE)
+        .withValue(new IntValue(REVISION, revision));
+  }
+
+  public static boolean hasDuplicatedRevision(List<Result> results) {
+    IntStream revisions = results.stream().mapToInt(r -> getRevisionFromResult(r));
+
+    Set<Integer> tempSet = new HashSet<>();
+    return revisions.anyMatch(rev -> !tempSet.add(rev));
+  }
+
+  public static int getMaxRevision(List<Result> results) {
+    OptionalInt maxRevision = results.stream().mapToInt(r -> getRevisionFromResult(r)).max();
+
+    return maxRevision.isPresent() ? maxRevision.getAsInt() : 0;
+  }
+
+  private static int getRevisionFromResult(Result result) {
+    return ((IntValue) result.getValue(REVISION).get()).get();
+  }
+}

--- a/scalardb-test/src/main/java/kelpie/scalardb/sensor/SensorCommon.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/sensor/SensorCommon.java
@@ -53,7 +53,7 @@ public class SensorCommon {
   public static int getMaxRevision(List<Result> results) {
     OptionalInt maxRevision = results.stream().mapToInt(r -> getRevisionFromResult(r)).max();
 
-    return maxRevision.isPresent() ? maxRevision.getAsInt() : 0;
+    return maxRevision.orElse(0);
   }
 
   private static int getRevisionFromResult(Result result) {

--- a/scalardb-test/src/main/java/kelpie/scalardb/sensor/SensorPreparer.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/sensor/SensorPreparer.java
@@ -1,0 +1,18 @@
+package kelpie.scalardb.sensor;
+
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.PreProcessor;
+
+public class SensorPreparer extends PreProcessor {
+  public SensorPreparer(Config config) {
+    super(config);
+  }
+
+  @Override
+  public void execute() {
+    logInfo("nothing to do for the preparation");
+  }
+
+  @Override
+  public void close() {}
+}

--- a/scalardb-test/src/main/java/kelpie/scalardb/sensor/SensorProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/sensor/SensorProcessor.java
@@ -1,0 +1,122 @@
+package kelpie.scalardb.sensor;
+
+import com.scalar.db.api.DistributedTransaction;
+import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.api.Isolation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.exception.transaction.TransactionException;
+import com.scalar.db.exception.transaction.UnknownTransactionStatusException;
+import com.scalar.db.transaction.consensuscommit.SerializableStrategy;
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.exception.ProcessFatalException;
+import com.scalar.kelpie.modules.TimeBasedProcessor;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.json.Json;
+
+public class SensorProcessor extends TimeBasedProcessor {
+  private final DistributedTransactionManager manager;
+  private final int numDevices;
+  private final AtomicBoolean isVerification;
+  private final AtomicBoolean isSerializable;
+  private final AtomicBoolean isExtraRead;
+  private final AtomicInteger numUpdates = new AtomicInteger(0);
+  private final int startTimestamp;
+
+  public SensorProcessor(Config config) {
+    super(config);
+    this.manager = SensorCommon.getTransactionManager(config);
+    this.numDevices = (int) config.getUserLong("test_config", "num_devices");
+    this.isVerification =
+        new AtomicBoolean(config.getUserBoolean("test_config", "is_verification", false));
+    this.isSerializable =
+        new AtomicBoolean(config.getUserBoolean("test_config", "is_serializable", false));
+    this.isExtraRead =
+        new AtomicBoolean(config.getUserBoolean("test_config", "is_extra_read", false));
+    this.startTimestamp = (int) (System.currentTimeMillis() / 1000L);
+  }
+
+  @Override
+  public void executeEach() throws Exception {
+    Isolation isolation = isSerializable.get() ? Isolation.SERIALIZABLE : Isolation.SNAPSHOT;
+    SerializableStrategy strategy =
+        isExtraRead.get() ? SerializableStrategy.EXTRA_READ : SerializableStrategy.EXTRA_WRITE;
+    DistributedTransaction transaction = manager.start(isolation, strategy);
+
+    String txId = transaction.getId();
+    int timestamp = (int) (System.currentTimeMillis() / 1000L);
+    int deviceId = ThreadLocalRandom.current().nextInt(numDevices);
+    logStart(txId, timestamp, deviceId);
+    try {
+      updateRevision(transaction, timestamp, deviceId);
+    } catch (Exception e) {
+      logFailure(txId, timestamp, deviceId, e);
+      throw e;
+    }
+
+    logSuccess(txId, timestamp, deviceId);
+  }
+
+  @Override
+  public void close() {
+    int endTimestamp = (int) (System.currentTimeMillis() / 1000L);
+
+    setState(
+        Json.createObjectBuilder()
+            .add("start_timestamp", startTimestamp)
+            .add("end_timestamp", endTimestamp)
+            .build());
+  }
+
+  private void updateRevision(DistributedTransaction transaction, int timestamp, int deviceId)
+      throws TransactionException {
+
+    Scan scan = SensorCommon.prepareScan(timestamp);
+    List<Result> results = transaction.scan(scan);
+
+    boolean hasDuplicatedRevision = SensorCommon.hasDuplicatedRevision(results);
+    if (hasDuplicatedRevision) {
+      throw new ProcessFatalException("A revision is duplicated at " + timestamp);
+    }
+
+    int revision = SensorCommon.getMaxRevision(results) + 1;
+    Put put = SensorCommon.preparePut(timestamp, deviceId, revision);
+    transaction.put(put);
+
+    transaction.commit();
+  }
+
+  private void logStart(String txId, int timestamp, int deviceId) {
+    if (isVerification.get()) {
+      logTxInfo("started", txId, timestamp, deviceId);
+    }
+  }
+
+  private void logSuccess(String txId, int timestamp, int deviceId) {
+    if (isVerification.get()) {
+      logTxInfo("succeeded", txId, timestamp, deviceId);
+    }
+  }
+
+  private void logFailure(String txId, int timestamp, int deviceId, Throwable e) {
+    if (isVerification.get()) {
+      logTxInfo("started", txId, timestamp, deviceId);
+    }
+
+    if (e instanceof UnknownTransactionStatusException) {
+      logWarn("the status of the transaction is unknown: " + txId, e);
+      logTxInfo("unknown", txId, timestamp, deviceId);
+    } else {
+      logWarn(txId + " failed", e);
+      logTxInfo("failed", txId, timestamp, deviceId);
+    }
+  }
+
+  private void logTxInfo(String status, String txId, int timestamp, int deviceId) {
+    logInfo(status + " - id: " + txId + " timestamp: " + timestamp + " deviceId: " + deviceId);
+  }
+}


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-6512

Add a pseudo sensor application for a phantom write test
  - Sensor log with a unique revision from multiple devices
  - A log is requested in each second
  - Transactions try to insert/update the revision after reading other devices’ records 

### Transaction
1. Scan all records in the current timestamp `t0`
2. Check the maximum revision `r0`
    - If the revision number is duplicated, the test should stop immediately because some transactions have broken serializable consistency
3. Update the revision of a device with revision `r0 + 1`
    - If there is no record in the timestamp, the transaction inserts a new record with revision `1`
