### PR TITLE
Replace implementation with api

### DIFF
--- a/scalardl-test/build.gradle
+++ b/scalardl-test/build.gradle
@@ -11,7 +11,7 @@ repositories {
 dependencies {
     implementation group: 'com.scalar-labs', name: 'kelpie', version: '1.1.0'
     implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '2.1.0'
-    implementation group: 'com.scalar-labs', name: 'scalardb', version: '2.4.1'
+    api group: 'com.scalar-labs', name: 'scalardb', version: '2.4.1'
     implementation group: "io.github.resilience4j", name: "resilience4j-retry", version: "1.3.1"
 }
 


### PR DESCRIPTION
When using another storage instead of Cassandra, `TransferChecker` failed due to the dependency of Scalar DB.