### PR TITLE
add a warning message to debug easily

### DIFF
--- a/scalardl-test/src/main/java/scalardl/transfer/TransferChecker.java
+++ b/scalardl-test/src/main/java/scalardl/transfer/TransferChecker.java
@@ -78,6 +78,7 @@ public class TransferChecker extends PostProcessor {
         results.add(result);
       } catch (Exception e) {
         // continue to read other records
+        logWarn("failed to read asset_id " + i, e);
         isFailed = true;
       }
     }


### PR DESCRIPTION
Added a warning message since it sometimes fails to recover forever even if records can be manually read.