### PR TITLE
Refactoring Scalar DB JdbcDatabaseConfig to JdbcConfig in kelpie-test

### DIFF
--- a/scalardb-test/README.md
+++ b/scalardb-test/README.md
@@ -4,18 +4,22 @@
 1. Set up an environment
     - This job requires a client to execute this job and Cassandra cluster or Cosmos DB which can be accessed from the client
 
-2. Build
+1. Update the `JdbcConfig` instead of `JdbcDatabaseConfig` in the following files If you are using Scalar DB 3.0.0 or older versions.
+    * [Common](src/main/java/kelpie/scalardb/Common.java)
+    * [NontransactionalTransferProcessor](src/main/java/kelpie/scalardb/transfer/jdbc/NontransactionalTransferProcessor.java)
+
+1. Build
     ```console
     $ gradle shadowJar
     ```
 
-3. Make your config file based on `benchmark-config.toml` or `verification-config.toml`
+1. Make your config file based on `benchmark-config.toml` or `verification-config.toml`
 
-4. Download Kelpie binary (zip) from https://github.com/scalar-labs/kelpie/releases/ and unzip it
+1. Download Kelpie binary (zip) from https://github.com/scalar-labs/kelpie/releases/ and unzip it
     - You can also build Kelpie from the source
 
 
-5. Execute a job
+1. Execute a job
     ```console
     $ ${KELPIE}/bin/kelpie --config your_config.toml
     ```

--- a/scalardb-test/src/main/java/kelpie/scalardb/Common.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/Common.java
@@ -11,7 +11,7 @@ import com.scalar.db.service.StorageModule;
 import com.scalar.db.service.StorageService;
 import com.scalar.db.service.TransactionModule;
 import com.scalar.db.service.TransactionService;
-import com.scalar.db.storage.jdbc.JdbcDatabaseConfig;
+import com.scalar.db.storage.jdbc.JdbcConfig;
 import com.scalar.db.transaction.consensuscommit.Coordinator;
 import com.scalar.kelpie.config.Config;
 import io.github.resilience4j.core.IntervalFunction;
@@ -62,27 +62,27 @@ public class Common {
         config.getUserLong(
             "storage_config",
             "jdbc_connection_pool_min_idle",
-            (long) JdbcDatabaseConfig.DEFAULT_CONNECTION_POOL_MIN_IDLE);
+            (long) JdbcConfig.DEFAULT_CONNECTION_POOL_MIN_IDLE);
     long jdbcConnectionPoolMaxIdle =
         config.getUserLong(
             "storage_config",
             "jdbc_connection_pool_max_idle",
-            (long) JdbcDatabaseConfig.DEFAULT_CONNECTION_POOL_MAX_IDLE);
+            (long) JdbcConfig.DEFAULT_CONNECTION_POOL_MAX_IDLE);
     long jdbcConnectionPoolMaxTotal =
         config.getUserLong(
             "storage_config",
             "jdbc_connection_pool_max_total",
-            (long) JdbcDatabaseConfig.DEFAULT_CONNECTION_POOL_MAX_TOTAL);
+            (long) JdbcConfig.DEFAULT_CONNECTION_POOL_MAX_TOTAL);
     boolean jdbcPreparedStatementsPoolEnabled =
         config.getUserBoolean(
             "storage_config",
             "jdbc_prepared_statements_pool_enabled",
-            JdbcDatabaseConfig.DEFAULT_PREPARED_STATEMENTS_POOL_ENABLED);
+            JdbcConfig.DEFAULT_PREPARED_STATEMENTS_POOL_ENABLED);
     long jdbcPreparedStatementsPoolMaxOpen =
         config.getUserLong(
             "storage_config",
             "jdbc_prepared_statements_pool_max_open",
-            (long) JdbcDatabaseConfig.DEFAULT_PREPARED_STATEMENTS_POOL_MAX_OPEN);
+            (long) JdbcConfig.DEFAULT_PREPARED_STATEMENTS_POOL_MAX_OPEN);
 
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, contactPoints);
@@ -99,16 +99,16 @@ public class Common {
     props.setProperty(DatabaseConfig.ISOLATION_LEVEL, isolationLevel);
     props.setProperty(DatabaseConfig.SERIALIZABLE_STRATEGY, serializableStrategy);
     props.setProperty(
-        JdbcDatabaseConfig.CONNECTION_POOL_MIN_IDLE, Long.toString(jdbcConnectionPoolMinIdle));
+        JdbcConfig.CONNECTION_POOL_MIN_IDLE, Long.toString(jdbcConnectionPoolMinIdle));
     props.setProperty(
-        JdbcDatabaseConfig.CONNECTION_POOL_MAX_IDLE, Long.toString(jdbcConnectionPoolMaxIdle));
+        JdbcConfig.CONNECTION_POOL_MAX_IDLE, Long.toString(jdbcConnectionPoolMaxIdle));
     props.setProperty(
-        JdbcDatabaseConfig.CONNECTION_POOL_MAX_TOTAL, Long.toString(jdbcConnectionPoolMaxTotal));
+        JdbcConfig.CONNECTION_POOL_MAX_TOTAL, Long.toString(jdbcConnectionPoolMaxTotal));
     props.setProperty(
-        JdbcDatabaseConfig.PREPARED_STATEMENTS_POOL_ENABLED,
+        JdbcConfig.PREPARED_STATEMENTS_POOL_ENABLED,
         Boolean.toString(jdbcPreparedStatementsPoolEnabled));
     props.setProperty(
-        JdbcDatabaseConfig.PREPARED_STATEMENTS_POOL_MAX_OPEN,
+        JdbcConfig.PREPARED_STATEMENTS_POOL_MAX_OPEN,
         Long.toString(jdbcPreparedStatementsPoolMaxOpen));
     return new DatabaseConfig(props);
   }

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/jdbc/NontransactionalTransferProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/jdbc/NontransactionalTransferProcessor.java
@@ -4,7 +4,7 @@ import static com.scalar.db.storage.jdbc.query.QueryUtils.enclose;
 import static com.scalar.db.storage.jdbc.query.QueryUtils.enclosedFullTableName;
 
 import com.scalar.db.config.DatabaseConfig;
-import com.scalar.db.storage.jdbc.JdbcDatabaseConfig;
+import com.scalar.db.storage.jdbc.JdbcConfig;
 import com.scalar.db.storage.jdbc.JdbcUtils;
 import com.scalar.db.storage.jdbc.RdbEngine;
 import com.scalar.kelpie.config.Config;
@@ -28,7 +28,7 @@ public class NontransactionalTransferProcessor extends TimeBasedProcessor {
     this.numAccounts = (int) config.getUserLong("test_config", "num_accounts");
 
     DatabaseConfig databaseConfig = Common.getDatabaseConfig(config);
-    dataSource = JdbcUtils.initDataSource(new JdbcDatabaseConfig(databaseConfig.getProperties()));
+    dataSource = JdbcUtils.initDataSource(new JdbcConfig(databaseConfig.getProperties()));
     rdbEngine = JdbcUtils.getRdbEngine(databaseConfig.getContactPoints().get(0));
     if (rdbEngine == RdbEngine.SQL_SERVER) {
       throw new IllegalArgumentException(RdbEngine.SQL_SERVER + " is not supported.");


### PR DESCRIPTION
Kelpie-test/scalardb-test updated based on [Refactoring the code around DatabaseConfig](https://github.com/scalar-labs/scalardb/commit/189059e25b5f13fe63df5fc66c8cda4585769d6a).

Ticket:- https://scalar-labs.atlassian.net/browse/DLT-9485