### PR TITLE
Remove namespace prefix from Scalar DB test

### DIFF
--- a/scalardb-test/benchmark-config.toml
+++ b/scalardb-test/benchmark-config.toml
@@ -26,7 +26,6 @@
   #username = "cassandra"
   #password = "cassandra"
   #storage = "cassandra"
-  #namespace_prefix = ""
   #isolation_level = "SNAPSHOT"
   #serializable_strategy = "EXTRA_READ"
 

--- a/scalardb-test/phantom-write-config.toml
+++ b/scalardb-test/phantom-write-config.toml
@@ -29,7 +29,6 @@
   #username = "cassandra"
   #password = "cassandra"
   #storage = "cassandra"
-  #namespace_prefix = ""
   isolation_level = "SERIALIZABLE"
   serializable_strategy = "EXTRA_READ"
 

--- a/scalardb-test/src/main/java/kelpie/scalardb/Common.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/Common.java
@@ -56,7 +56,6 @@ public class Common {
     String username = config.getUserString("storage_config", "username", "cassandra");
     String password = config.getUserString("storage_config", "password", "cassandra");
     String storage = config.getUserString("storage_config", "storage", "cassandra");
-    String prefix = config.getUserString("storage_config", "namespace_prefix", "");
     String isolationLevel = config.getUserString("storage_config", "isolation_level", "SNAPSHOT");
     String transactionManager =
         config.getUserString("storage_config", "transaction_manager", "consensus-commit");
@@ -103,7 +102,6 @@ public class Common {
     props.setProperty(DatabaseConfig.USERNAME, username);
     props.setProperty(DatabaseConfig.PASSWORD, password);
     props.setProperty(DatabaseConfig.STORAGE, storage);
-    props.setProperty(DatabaseConfig.NAMESPACE_PREFIX, prefix);
     props.setProperty(DatabaseConfig.TRANSACTION_MANAGER, transactionManager);
     props.setProperty(DatabaseConfig.ISOLATION_LEVEL, isolationLevel);
     props.setProperty(ConsensusCommitConfig.SERIALIZABLE_STRATEGY, serializableStrategy);

--- a/scalardb-test/verification-config.toml
+++ b/scalardb-test/verification-config.toml
@@ -30,7 +30,6 @@
   #username = "cassandra"
   #password = "cassandra"
   #storage = "cassandra"
-  #namespace_prefix = ""
   #isolation_level = "SNAPSHOT"
   #serializable_strategy = "EXTRA_READ"
 

--- a/scalardb-test/write-skew-config.toml
+++ b/scalardb-test/write-skew-config.toml
@@ -32,7 +32,6 @@
   #username = "cassandra"
   #password = "cassandra"
   #storage = "cassandra"
-  #namespace_prefix = ""
   isolation_level = "SERIALIZABLE"
   serializable_strategy = "EXTRA_READ"
 


### PR DESCRIPTION
In the latest Scalar DB, the namespace prefix is removed. We also need to remove it from the Scalar DB test in this project. Please take a look!