### PR TITLE
Add several workloads for storage API

### DIFF
--- a/scalardb-test/schema/multiple-clustering-key.json
+++ b/scalardb-test/schema/multiple-clustering-key.json
@@ -1,0 +1,17 @@
+{
+  "storage.multiple-clustering-key": {
+    "partition-key": [
+      "pkey"
+    ],
+    "clustering-key": [
+      "ckey1",
+      "ckey2"
+    ],
+    "columns": {
+      "pkey": "INT",
+      "ckey1": "INT",
+      "ckey2": "INT",
+      "col": "INT"
+    }
+  }
+}

--- a/scalardb-test/schema/no-clustering-key.json
+++ b/scalardb-test/schema/no-clustering-key.json
@@ -1,0 +1,12 @@
+{
+  "storage.no-clustering-key": {
+    "partition-key": [
+      "pkey"
+    ],
+    "clustering-key": [],
+    "columns": {
+      "pkey": "INT",
+      "col": "INT"
+    }
+  }
+}

--- a/scalardb-test/schema/single-clustering-key.json
+++ b/scalardb-test/schema/single-clustering-key.json
@@ -1,0 +1,15 @@
+{
+  "storage.single-clustering-key": {
+    "partition-key": [
+      "pkey"
+    ],
+    "clustering-key": [
+      "ckey"
+    ],
+    "columns": {
+      "pkey": "INT",
+      "ckey": "INT",
+      "col": "INT"
+    }
+  }
+}

--- a/scalardb-test/src/main/java/kelpie/scalardb/storage/MultipleClusteringKeyPreparer.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/storage/MultipleClusteringKeyPreparer.java
@@ -1,0 +1,106 @@
+package kelpie.scalardb.storage;
+
+import static kelpie.scalardb.storage.MultipleClusteringKeySchema.NUM_CLUSTERING_KEY1;
+import static kelpie.scalardb.storage.MultipleClusteringKeySchema.NUM_CLUSTERING_KEY2;
+import static kelpie.scalardb.storage.MultipleClusteringKeySchema.preparePut;
+import static kelpie.scalardb.storage.StorageCommon.DEFAULT_POPULATION_CONCURRENCY;
+
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Put;
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.PreProcessor;
+import io.github.resilience4j.retry.Retry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
+import kelpie.scalardb.Common;
+
+public class MultipleClusteringKeyPreparer extends PreProcessor {
+
+  private final DistributedStorage storage;
+
+  public MultipleClusteringKeyPreparer(Config config) {
+    super(config);
+    storage = Common.getStorage(config);
+  }
+
+  @Override
+  public void execute() {
+    logInfo("insert initial values... ");
+
+    int concurrency =
+        (int)
+            config.getUserLong(
+                "test_config", "population_concurrency", DEFAULT_POPULATION_CONCURRENCY);
+    ExecutorService es = Executors.newCachedThreadPool();
+    List<CompletableFuture<Void>> futures = new ArrayList<>();
+    IntStream.range(0, concurrency)
+        .forEach(
+            i -> {
+              CompletableFuture<Void> future =
+                  CompletableFuture.runAsync(() -> new PopulationRunner(i).run(), es);
+              futures.add(future);
+            });
+
+    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+    logInfo("all records have been inserted");
+  }
+
+  @Override
+  public void close() throws Exception {
+    storage.close();
+  }
+
+  private class PopulationRunner {
+    private final int id;
+
+    public PopulationRunner(int threadId) {
+      this.id = threadId;
+    }
+
+    public void run() {
+      int concurrency =
+          (int)
+              config.getUserLong(
+                  "test_config", "population_concurrency", DEFAULT_POPULATION_CONCURRENCY);
+      int numKeys = (int) config.getUserLong("test_config", "num_keys");
+      int numPerThread = (numKeys + concurrency - 1) / concurrency;
+      int startPKey = numPerThread * id;
+      int endPKey = Math.min(numPerThread * (id + 1), numKeys);
+      IntStream.range(startPKey, endPKey).forEach(this::populate);
+    }
+
+    private void populate(int pkey) {
+      Runnable populate =
+          () -> {
+            try {
+              for (int i = 0; i < NUM_CLUSTERING_KEY1; i++) {
+                List<Put> puts = new ArrayList<>(NUM_CLUSTERING_KEY2);
+                for (int j = 0; j < NUM_CLUSTERING_KEY2; j++) {
+                  Put put = preparePut(pkey, i, j, ThreadLocalRandom.current().nextInt());
+                  puts.add(put);
+                }
+                storage.put(puts);
+                MultipleClusteringKeyPreparer.this.logInfo(
+                    "(pkey=" + pkey + ", ckey1=" + i + ") inserted");
+              }
+            } catch (Exception e) {
+              throw new RuntimeException("population failed, retry", e);
+            }
+          };
+
+      Retry retry = Common.getRetryWithFixedWaitDuration("populate");
+      Runnable decorated = Retry.decorateRunnable(retry, populate);
+      try {
+        decorated.run();
+      } catch (Exception e) {
+        logError("population failed repeatedly!");
+        throw e;
+      }
+    }
+  }
+}

--- a/scalardb-test/src/main/java/kelpie/scalardb/storage/MultipleClusteringKeyReaderProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/storage/MultipleClusteringKeyReaderProcessor.java
@@ -1,0 +1,63 @@
+package kelpie.scalardb.storage;
+
+import static kelpie.scalardb.storage.MultipleClusteringKeySchema.NUM_CLUSTERING_KEY1;
+import static kelpie.scalardb.storage.MultipleClusteringKeySchema.NUM_CLUSTERING_KEY2;
+import static kelpie.scalardb.storage.MultipleClusteringKeySchema.prepareScan;
+
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.api.Scanner;
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.TimeBasedProcessor;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import kelpie.scalardb.transfer.TransferCommon;
+
+public class MultipleClusteringKeyReaderProcessor extends TimeBasedProcessor {
+  private final DistributedStorage storage;
+  private final int numKeys;
+  private final Order ckey1Order;
+  private final Order ckey2Order;
+
+  public MultipleClusteringKeyReaderProcessor(Config config) {
+    super(config);
+    storage = TransferCommon.getStorage(config);
+    numKeys = (int) config.getUserLong("test_config", "num_keys");
+
+    boolean reverse = config.getUserBoolean("test_config", "reverse_scan", false);
+    Order ckey1ClusteringOrder =
+        Order.valueOf(config.getUserString("test_config", "ckey1_clustering_order", "ASC"));
+    Order ckey2ClusteringOrder =
+        Order.valueOf(config.getUserString("test_config", "ckey2_clustering_order", "ASC"));
+    ckey1Order = !reverse ? ckey1ClusteringOrder : StorageCommon.reverseOrder(ckey1ClusteringOrder);
+    ckey2Order = !reverse ? ckey2ClusteringOrder : StorageCommon.reverseOrder(ckey2ClusteringOrder);
+  }
+
+  @Override
+  protected void executeEach() throws Exception {
+    int pkey = ThreadLocalRandom.current().nextInt(numKeys);
+    int ckey1 = ThreadLocalRandom.current().nextInt(NUM_CLUSTERING_KEY1);
+    Scan scan = prepareScan(pkey, ckey1, ckey1Order, ckey2Order);
+    try (Scanner scanner = storage.scan(scan)) {
+      List<Result> results = scanner.all();
+      if (results.size() != NUM_CLUSTERING_KEY2) {
+        logWarn(
+            "the number of results of the scan for (pkey="
+                + pkey
+                + ", ckey1="
+                + ckey1
+                + ") should be "
+                + NUM_CLUSTERING_KEY2
+                + ", but "
+                + results.size());
+      }
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    storage.close();
+  }
+}

--- a/scalardb-test/src/main/java/kelpie/scalardb/storage/MultipleClusteringKeySchema.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/storage/MultipleClusteringKeySchema.java
@@ -1,0 +1,44 @@
+package kelpie.scalardb.storage;
+
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.Scan.Ordering;
+import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.io.Key;
+
+public final class MultipleClusteringKeySchema {
+
+  public static final String NAMESPACE = "storage";
+  public static final String TABLE = "multiple-clustering-key";
+  public static final String PARTITION_KEY = "pkey";
+  public static final String CLUSTERING_KEY1 = "ckey1";
+  public static final String CLUSTERING_KEY2 = "ckey2";
+  public static final String COL = "col";
+
+  public static final int NUM_CLUSTERING_KEY1 = 10;
+  public static final int NUM_CLUSTERING_KEY2 = 100;
+
+  private MultipleClusteringKeySchema() {}
+
+  public static Put preparePut(int pkey, int ckey1, int ckey2, int colValue) {
+    Key partitionKey = new Key(PARTITION_KEY, pkey);
+    Key clusteringKey =
+        Key.newBuilder().addInt(CLUSTERING_KEY1, ckey1).addInt(CLUSTERING_KEY2, ckey2).build();
+    return new Put(partitionKey, clusteringKey)
+        .withValue(COL, colValue)
+        .forNamespace(NAMESPACE)
+        .forTable(TABLE);
+  }
+
+  public static Scan prepareScan(int pkey, int ckey1, Order ckey1Order, Order ckey2Order) {
+    Key partitionKey = new Key(PARTITION_KEY, pkey);
+    Key clusteringKey1 = new Key(CLUSTERING_KEY1, ckey1);
+    return new Scan(partitionKey)
+        .withStart(clusteringKey1)
+        .withEnd(clusteringKey1)
+        .withOrdering(new Ordering(CLUSTERING_KEY1, ckey1Order))
+        .withOrdering(new Ordering(CLUSTERING_KEY2, ckey2Order))
+        .forNamespace(NAMESPACE)
+        .forTable(TABLE);
+  }
+}

--- a/scalardb-test/src/main/java/kelpie/scalardb/storage/MultipleClusteringKeyWriterProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/storage/MultipleClusteringKeyWriterProcessor.java
@@ -1,0 +1,39 @@
+package kelpie.scalardb.storage;
+
+import static kelpie.scalardb.storage.MultipleClusteringKeySchema.NUM_CLUSTERING_KEY1;
+import static kelpie.scalardb.storage.MultipleClusteringKeySchema.NUM_CLUSTERING_KEY2;
+import static kelpie.scalardb.storage.MultipleClusteringKeySchema.preparePut;
+
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Put;
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.TimeBasedProcessor;
+import java.util.concurrent.ThreadLocalRandom;
+import kelpie.scalardb.transfer.TransferCommon;
+
+public class MultipleClusteringKeyWriterProcessor extends TimeBasedProcessor {
+  private final DistributedStorage storage;
+  private final int numKeys;
+
+  public MultipleClusteringKeyWriterProcessor(Config config) {
+    super(config);
+    storage = TransferCommon.getStorage(config);
+    numKeys = (int) config.getUserLong("test_config", "num_keys");
+  }
+
+  @Override
+  protected void executeEach() throws Exception {
+    int pkey = ThreadLocalRandom.current().nextInt(numKeys);
+    int ckey1 = ThreadLocalRandom.current().nextInt(NUM_CLUSTERING_KEY1);
+    int ckey2 = ThreadLocalRandom.current().nextInt(NUM_CLUSTERING_KEY2);
+    int colValue = ThreadLocalRandom.current().nextInt();
+
+    Put put = preparePut(pkey, ckey1, ckey2, colValue);
+    storage.put(put);
+  }
+
+  @Override
+  public void close() throws Exception {
+    storage.close();
+  }
+}

--- a/scalardb-test/src/main/java/kelpie/scalardb/storage/NoClusteringKeyPreparer.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/storage/NoClusteringKeyPreparer.java
@@ -1,0 +1,96 @@
+package kelpie.scalardb.storage;
+
+import static kelpie.scalardb.storage.NoClusteringKeySchema.preparePut;
+import static kelpie.scalardb.storage.StorageCommon.DEFAULT_POPULATION_CONCURRENCY;
+
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.PreProcessor;
+import io.github.resilience4j.retry.Retry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
+import kelpie.scalardb.Common;
+import kelpie.scalardb.transfer.TransferCommon;
+
+public class NoClusteringKeyPreparer extends PreProcessor {
+
+  private final DistributedStorage storage;
+
+  public NoClusteringKeyPreparer(Config config) {
+    super(config);
+    this.storage = TransferCommon.getStorage(config);
+  }
+
+  @Override
+  public void execute() {
+    logInfo("insert initial values... ");
+
+    int concurrency =
+        (int)
+            config.getUserLong(
+                "test_config", "population_concurrency", DEFAULT_POPULATION_CONCURRENCY);
+    ExecutorService es = Executors.newCachedThreadPool();
+    List<CompletableFuture<Void>> futures = new ArrayList<>();
+    IntStream.range(0, concurrency)
+        .forEach(
+            i -> {
+              CompletableFuture<Void> future =
+                  CompletableFuture.runAsync(() -> new PopulationRunner(i).run(), es);
+              futures.add(future);
+            });
+
+    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+    logInfo("all records have been inserted");
+  }
+
+  @Override
+  public void close() throws Exception {
+    storage.close();
+  }
+
+  private class PopulationRunner {
+    private final int id;
+
+    public PopulationRunner(int threadId) {
+      this.id = threadId;
+    }
+
+    public void run() {
+      int concurrency =
+          (int)
+              config.getUserLong(
+                  "test_config", "population_concurrency", DEFAULT_POPULATION_CONCURRENCY);
+      int numKeys = (int) config.getUserLong("test_config", "num_keys");
+      int numPerThread = (numKeys + concurrency - 1) / concurrency;
+      int start = numPerThread * id;
+      int end = Math.min(numPerThread * (id + 1), numKeys);
+      IntStream.range(start, end).forEach(this::populate);
+    }
+
+    private void populate(int pkey) {
+      Runnable populate =
+          () -> {
+            try {
+              storage.put(preparePut(pkey, ThreadLocalRandom.current().nextInt()));
+              NoClusteringKeyPreparer.this.logInfo("pkey=" + pkey + " inserted");
+            } catch (Exception e) {
+              throw new RuntimeException("population failed, retry", e);
+            }
+          };
+
+      Retry retry = Common.getRetryWithFixedWaitDuration("populate");
+      Runnable decorated = Retry.decorateRunnable(retry, populate);
+      try {
+        decorated.run();
+      } catch (Exception e) {
+        logError("population failed repeatedly!");
+        throw e;
+      }
+    }
+  }
+}

--- a/scalardb-test/src/main/java/kelpie/scalardb/storage/NoClusteringKeyReaderProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/storage/NoClusteringKeyReaderProcessor.java
@@ -1,0 +1,36 @@
+package kelpie.scalardb.storage;
+
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Result;
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.TimeBasedProcessor;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import kelpie.scalardb.transfer.TransferCommon;
+
+public class NoClusteringKeyReaderProcessor extends TimeBasedProcessor {
+  private final DistributedStorage storage;
+  private final int numKeys;
+
+  public NoClusteringKeyReaderProcessor(Config config) {
+    super(config);
+    storage = TransferCommon.getStorage(config);
+    numKeys = (int) config.getUserLong("test_config", "num_keys");
+  }
+
+  @Override
+  protected void executeEach() throws Exception {
+    int pkey = ThreadLocalRandom.current().nextInt(numKeys);
+    Get get = NoClusteringKeySchema.prepareGet(pkey);
+    Optional<Result> result = storage.get(get);
+    if (!result.isPresent()) {
+      logWarn("the results should exist, but not");
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    storage.close();
+  }
+}

--- a/scalardb-test/src/main/java/kelpie/scalardb/storage/NoClusteringKeySchema.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/storage/NoClusteringKeySchema.java
@@ -1,0 +1,25 @@
+package kelpie.scalardb.storage;
+
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Put;
+import com.scalar.db.io.Key;
+
+public class NoClusteringKeySchema {
+
+  public static final String NAMESPACE = "storage";
+  public static final String TABLE = "no-clustering-key";
+  public static final String PARTITION_KEY = "pkey";
+  public static final String COL = "col";
+
+  private NoClusteringKeySchema() {}
+
+  public static Put preparePut(int pkey, int colValue) {
+    Key partitionKey = new Key(PARTITION_KEY, pkey);
+    return new Put(partitionKey).withValue(COL, colValue).forNamespace(NAMESPACE).forTable(TABLE);
+  }
+
+  public static Get prepareGet(int pkey) {
+    Key partitionKey = new Key(PARTITION_KEY, pkey);
+    return new Get(partitionKey).forNamespace(NAMESPACE).forTable(TABLE);
+  }
+}

--- a/scalardb-test/src/main/java/kelpie/scalardb/storage/NoClusteringKeyWriterProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/storage/NoClusteringKeyWriterProcessor.java
@@ -1,0 +1,34 @@
+package kelpie.scalardb.storage;
+
+import static kelpie.scalardb.storage.NoClusteringKeySchema.preparePut;
+
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Put;
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.TimeBasedProcessor;
+import java.util.concurrent.ThreadLocalRandom;
+import kelpie.scalardb.transfer.TransferCommon;
+
+public class NoClusteringKeyWriterProcessor extends TimeBasedProcessor {
+  private final DistributedStorage storage;
+  private final int numKeys;
+
+  public NoClusteringKeyWriterProcessor(Config config) {
+    super(config);
+    storage = TransferCommon.getStorage(config);
+    numKeys = (int) config.getUserLong("test_config", "num_keys");
+  }
+
+  @Override
+  protected void executeEach() throws Exception {
+    int pkey = ThreadLocalRandom.current().nextInt(numKeys);
+    int colValue = ThreadLocalRandom.current().nextInt();
+    Put put = preparePut(pkey, colValue);
+    storage.put(put);
+  }
+
+  @Override
+  public void close() throws Exception {
+    storage.close();
+  }
+}

--- a/scalardb-test/src/main/java/kelpie/scalardb/storage/SingleClusteringKeyPreparer.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/storage/SingleClusteringKeyPreparer.java
@@ -1,0 +1,103 @@
+package kelpie.scalardb.storage;
+
+import static kelpie.scalardb.storage.SingleClusteringKeySchema.NUM_CLUSTERING_KEY;
+import static kelpie.scalardb.storage.SingleClusteringKeySchema.preparePut;
+import static kelpie.scalardb.storage.StorageCommon.DEFAULT_POPULATION_CONCURRENCY;
+
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Put;
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.PreProcessor;
+import io.github.resilience4j.retry.Retry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
+import kelpie.scalardb.Common;
+import kelpie.scalardb.transfer.TransferCommon;
+
+public class SingleClusteringKeyPreparer extends PreProcessor {
+
+  private final DistributedStorage storage;
+
+  public SingleClusteringKeyPreparer(Config config) {
+    super(config);
+    this.storage = TransferCommon.getStorage(config);
+  }
+
+  @Override
+  public void execute() {
+    logInfo("insert initial values... ");
+
+    int concurrency =
+        (int)
+            config.getUserLong(
+                "test_config", "population_concurrency", DEFAULT_POPULATION_CONCURRENCY);
+    ExecutorService es = Executors.newCachedThreadPool();
+    List<CompletableFuture<Void>> futures = new ArrayList<>();
+    IntStream.range(0, concurrency)
+        .forEach(
+            i -> {
+              CompletableFuture<Void> future =
+                  CompletableFuture.runAsync(() -> new PopulationRunner(i).run(), es);
+              futures.add(future);
+            });
+
+    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+    logInfo("all records have been inserted");
+  }
+
+  @Override
+  public void close() throws Exception {
+    storage.close();
+  }
+
+  private class PopulationRunner {
+    private final int id;
+
+    public PopulationRunner(int threadId) {
+      this.id = threadId;
+    }
+
+    public void run() {
+      int concurrency =
+          (int)
+              config.getUserLong(
+                  "test_config", "population_concurrency", DEFAULT_POPULATION_CONCURRENCY);
+      int numKeys = (int) config.getUserLong("test_config", "num_keys");
+      int numPerThread = (numKeys + concurrency - 1) / concurrency;
+      int start = numPerThread * id;
+      int end = Math.min(numPerThread * (id + 1), numKeys);
+      IntStream.range(start, end).forEach(this::populate);
+    }
+
+    private void populate(int pkey) {
+      Runnable populate =
+          () -> {
+            try {
+              List<Put> puts = new ArrayList<>(NUM_CLUSTERING_KEY);
+              for (int i = 0; i < NUM_CLUSTERING_KEY; i++) {
+                Put put = preparePut(pkey, i, ThreadLocalRandom.current().nextInt());
+                puts.add(put);
+              }
+              storage.put(puts);
+              SingleClusteringKeyPreparer.this.logInfo("pkey=" + pkey + " inserted");
+            } catch (Exception e) {
+              throw new RuntimeException("population failed, retry", e);
+            }
+          };
+
+      Retry retry = Common.getRetryWithFixedWaitDuration("populate");
+      Runnable decorated = Retry.decorateRunnable(retry, populate);
+      try {
+        decorated.run();
+      } catch (Exception e) {
+        logError("population failed repeatedly!");
+        throw e;
+      }
+    }
+  }
+}

--- a/scalardb-test/src/main/java/kelpie/scalardb/storage/SingleClusteringKeyReaderProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/storage/SingleClusteringKeyReaderProcessor.java
@@ -1,0 +1,55 @@
+package kelpie.scalardb.storage;
+
+import static kelpie.scalardb.storage.SingleClusteringKeySchema.NUM_CLUSTERING_KEY;
+import static kelpie.scalardb.storage.SingleClusteringKeySchema.prepareScan;
+
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.api.Scanner;
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.TimeBasedProcessor;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import kelpie.scalardb.transfer.TransferCommon;
+
+public class SingleClusteringKeyReaderProcessor extends TimeBasedProcessor {
+  private final DistributedStorage storage;
+  private final int numKeys;
+  private final Order ckeyOrder;
+
+  public SingleClusteringKeyReaderProcessor(Config config) {
+    super(config);
+    storage = TransferCommon.getStorage(config);
+    numKeys = (int) config.getUserLong("test_config", "num_keys");
+
+    boolean reverse = config.getUserBoolean("test_config", "reverse_scan", false);
+    Order ckey1ClusteringOrder =
+        Order.valueOf(config.getUserString("test_config", "ckey_clustering_order", "ASC"));
+    ckeyOrder = !reverse ? ckey1ClusteringOrder : StorageCommon.reverseOrder(ckey1ClusteringOrder);
+  }
+
+  @Override
+  protected void executeEach() throws Exception {
+    int pkey = ThreadLocalRandom.current().nextInt(numKeys);
+    Scan scan = prepareScan(pkey, ckeyOrder);
+    try (Scanner scanner = storage.scan(scan)) {
+      List<Result> results = scanner.all();
+      if (results.size() != NUM_CLUSTERING_KEY) {
+        logWarn(
+            "the number of results of the scan for (pkey="
+                + pkey
+                + ") should be "
+                + NUM_CLUSTERING_KEY
+                + ", but "
+                + results.size());
+      }
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    storage.close();
+  }
+}

--- a/scalardb-test/src/main/java/kelpie/scalardb/storage/SingleClusteringKeySchema.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/storage/SingleClusteringKeySchema.java
@@ -1,0 +1,37 @@
+package kelpie.scalardb.storage;
+
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Scan;
+import com.scalar.db.api.Scan.Ordering;
+import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.io.Key;
+
+public final class SingleClusteringKeySchema {
+
+  public static final String NAMESPACE = "storage";
+  public static final String TABLE = "single-clustering-key";
+  public static final String PARTITION_KEY = "pkey";
+  public static final String CLUSTERING_KEY = "ckey";
+  public static final String COL = "col";
+
+  public static final int NUM_CLUSTERING_KEY = 100;
+
+  private SingleClusteringKeySchema() {}
+
+  public static Put preparePut(int pkey, int ckey, int colValue) {
+    Key partitionKey = new Key(PARTITION_KEY, pkey);
+    Key clusteringKey = new Key(CLUSTERING_KEY, ckey);
+    return new Put(partitionKey, clusteringKey)
+        .withValue(COL, colValue)
+        .forNamespace(NAMESPACE)
+        .forTable(TABLE);
+  }
+
+  public static Scan prepareScan(int pkey, Order ckeyOrder) {
+    Key partitionKey = new Key(PARTITION_KEY, pkey);
+    return new Scan(partitionKey)
+        .withOrdering(new Ordering(CLUSTERING_KEY, ckeyOrder))
+        .forNamespace(NAMESPACE)
+        .forTable(TABLE);
+  }
+}

--- a/scalardb-test/src/main/java/kelpie/scalardb/storage/SingleClusteringKeyWriterProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/storage/SingleClusteringKeyWriterProcessor.java
@@ -1,0 +1,37 @@
+package kelpie.scalardb.storage;
+
+import static kelpie.scalardb.storage.SingleClusteringKeySchema.NUM_CLUSTERING_KEY;
+import static kelpie.scalardb.storage.SingleClusteringKeySchema.preparePut;
+
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Put;
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.TimeBasedProcessor;
+import java.util.concurrent.ThreadLocalRandom;
+import kelpie.scalardb.transfer.TransferCommon;
+
+public class SingleClusteringKeyWriterProcessor extends TimeBasedProcessor {
+  private final DistributedStorage storage;
+  private final int numKeys;
+
+  public SingleClusteringKeyWriterProcessor(Config config) {
+    super(config);
+    storage = TransferCommon.getStorage(config);
+    numKeys = (int) config.getUserLong("test_config", "num_keys");
+  }
+
+  @Override
+  protected void executeEach() throws Exception {
+    int pkey = ThreadLocalRandom.current().nextInt(numKeys);
+    int ckey = ThreadLocalRandom.current().nextInt(NUM_CLUSTERING_KEY);
+    int colValue = ThreadLocalRandom.current().nextInt();
+
+    Put put = preparePut(pkey, ckey, colValue);
+    storage.put(put);
+  }
+
+  @Override
+  public void close() throws Exception {
+    storage.close();
+  }
+}

--- a/scalardb-test/src/main/java/kelpie/scalardb/storage/StorageCommon.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/storage/StorageCommon.java
@@ -1,0 +1,21 @@
+package kelpie.scalardb.storage;
+
+import com.scalar.db.api.Scan.Ordering.Order;
+
+public final class StorageCommon {
+
+  public static final long DEFAULT_POPULATION_CONCURRENCY = 32L;
+
+  private StorageCommon() {}
+
+  public static Order reverseOrder(Order order) {
+    switch (order) {
+      case ASC:
+        return Order.DESC;
+      case DESC:
+        return Order.ASC;
+      default:
+        throw new AssertionError("unknown order: " + order);
+    }
+  }
+}

--- a/scalardb-test/src/main/java/kelpie/scalardb/storage/StorageReporter.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/storage/StorageReporter.java
@@ -1,0 +1,19 @@
+package kelpie.scalardb.storage;
+
+import com.scalar.kelpie.config.Config;
+import com.scalar.kelpie.modules.PostProcessor;
+
+public class StorageReporter extends PostProcessor {
+
+  public StorageReporter(Config config) {
+    super(config);
+  }
+
+  @Override
+  public void execute() {
+    getSummary();
+  }
+
+  @Override
+  public void close() {}
+}


### PR DESCRIPTION
This PR adds the following workloads:
- Scan operations on Single clustering key schema (SingleClusteringKeyReaderProcessor)
- Scan operations on Multiple clustering key schema (MultipleClusteringKeyReaderProcessor)
- Get operations on no clustering key schema (NoClusteringKeyReaderProcessor)
- Put operations on Single clustering key schema (SingleClusteringKeyWriterProcessor)
- Put operations on Multiple clustering key schema (MultipleClusteringKeyWriterProcessor)
- Put operations on no clustering key schema (NoClusteringKeyWriterProcessor)

Please take a look!