### PR TITLE
Add a delay in post process phase

### DIFF
--- a/scalardl-test/src/main/java/scalardl/transfer/TransferChecker.java
+++ b/scalardl-test/src/main/java/scalardl/transfer/TransferChecker.java
@@ -27,17 +27,18 @@ import scalardl.Common;
 
 public class TransferChecker extends PostProcessor {
 
-  private final int SLEEP_TIME_MILLISECONDS = 60000;
+  private final long sleepTimeMilliseconds;
 
   public TransferChecker(Config config) {
     super(config);
+    this.sleepTimeMilliseconds =  config.getUserLong("test_config", "sleep_time_milli_sec", 0L);
   }
 
   @Override
   public void execute() {
 
     try {
-      Thread.sleep(SLEEP_TIME_MILLISECONDS);
+      Thread.sleep(sleepTimeMilliseconds);
     } catch (InterruptedException ie) {
       logInfo("Interrupted exception occurred during sleep");
       // Interrupt flag is set back to true to indicate interruption

--- a/scalardl-test/src/main/java/scalardl/transfer/TransferChecker.java
+++ b/scalardl-test/src/main/java/scalardl/transfer/TransferChecker.java
@@ -27,12 +27,23 @@ import scalardl.Common;
 
 public class TransferChecker extends PostProcessor {
 
+  private final int SLEEP_TIME_MILLISECONDS = 60000;
+
   public TransferChecker(Config config) {
     super(config);
   }
 
   @Override
   public void execute() {
+
+    try {
+      Thread.sleep(SLEEP_TIME_MILLISECONDS);
+    } catch (InterruptedException ie) {
+      logInfo("Interrupted exception occurred during sleep");
+      // Interrupt flag is set back to true to indicate interruption
+      Thread.currentThread().interrupt();
+    }
+
     List<JsonObject> results = readBalancesWithRetry();
 
     int committed = getNumOfCommittedFromCoordinator();

--- a/scalardl-test/verification-config.toml
+++ b/scalardl-test/verification-config.toml
@@ -24,6 +24,7 @@
   is_verification = true
   num_accounts = 10
   population_concurrency = 32
+  sleep_time_milli_sec = 60000
 
 [storage_config]
   contact_points = "localhost"


### PR DESCRIPTION
I have added a delay of 60 seconds before read in post process is started by adding a 60 second sleep.
This is to fix the `read failed repeatedly` issue occurring frequently in daily periodic scalar DL verification test.
I have added `Thread.currentThread().interrupt();` in catch block for InterruptedException as I was not sure whether it was a good idea to ignore the exception in the test.