### PR TITLE
Change read retry count and retry interval sleep configurable

### DIFF
--- a/scalardl-test/src/main/java/scalardl/Common.java
+++ b/scalardl-test/src/main/java/scalardl/Common.java
@@ -19,9 +19,9 @@ public class Common {
   private static String AUDITOR_ENABLED = "false";
   private static ClientConfig config;
   private static final String CERT_HOLDER_ID = "test_holder";
-  private static final int MAX_RETRIES = 10;
+  private static int MAX_RETRIES = 10;
   private static final Duration WAIT_DURATION = Duration.ofMillis(1000);
-  private static final long SLEEP_BASE_MILLIS = 100L;
+  private static long SLEEP_BASE_MILLIS = 100L;
 
   public static final int INITIAL_BALANCE = 10000;
 
@@ -80,5 +80,10 @@ public class Common {
         RetryConfig.custom().maxAttempts(MAX_RETRIES).intervalFunction(intervalFunc).build();
 
     return Retry.of(name, retryConfig);
+  }
+
+  public static void setIntervalAndMaxRetry(Config config){
+    SLEEP_BASE_MILLIS = config.getUserLong("common", "sleep_base_millis", 1000L);
+    MAX_RETRIES = (int) config.getUserLong("common", "max_retries", 10L);
   }
 }

--- a/scalardl-test/src/main/java/scalardl/Common.java
+++ b/scalardl-test/src/main/java/scalardl/Common.java
@@ -19,9 +19,9 @@ public class Common {
   private static String AUDITOR_ENABLED = "false";
   private static ClientConfig config;
   private static final String CERT_HOLDER_ID = "test_holder";
-  private static int MAX_RETRIES = 10;
+  private static final int MAX_RETRIES = 10;
   private static final Duration WAIT_DURATION = Duration.ofMillis(1000);
-  private static long SLEEP_BASE_MILLIS = 100L;
+  private static final long SLEEP_BASE_MILLIS = 100L;
 
   public static final int INITIAL_BALANCE = 10000;
 
@@ -82,8 +82,12 @@ public class Common {
     return Retry.of(name, retryConfig);
   }
 
-  public static void setIntervalAndMaxRetry(Config config){
-    SLEEP_BASE_MILLIS = config.getUserLong("common", "sleep_base_millis", 1000L);
-    MAX_RETRIES = (int) config.getUserLong("common", "max_retries", 10L);
+  public static Retry getRetryWithExponentialBackoff(String name, int maxRetries, long waitMillis) {
+    IntervalFunction intervalFunc = IntervalFunction.ofExponentialBackoff(waitMillis, 2.0);
+
+    RetryConfig retryConfig =
+            RetryConfig.custom().maxAttempts(maxRetries).intervalFunction(intervalFunc).build();
+
+    return Retry.of(name, retryConfig);
   }
 }

--- a/scalardl-test/src/main/java/scalardl/Common.java
+++ b/scalardl-test/src/main/java/scalardl/Common.java
@@ -74,12 +74,7 @@ public class Common {
   }
 
   public static Retry getRetryWithExponentialBackoff(String name) {
-    IntervalFunction intervalFunc = IntervalFunction.ofExponentialBackoff(SLEEP_BASE_MILLIS, 2.0);
-
-    RetryConfig retryConfig =
-        RetryConfig.custom().maxAttempts(MAX_RETRIES).intervalFunction(intervalFunc).build();
-
-    return Retry.of(name, retryConfig);
+    return getRetryWithExponentialBackoff(name, MAX_RETRIES, SLEEP_BASE_MILLIS);
   }
 
   public static Retry getRetryWithExponentialBackoff(String name, int maxRetries, long waitMillis) {

--- a/scalardl-test/src/main/java/scalardl/transfer/TransferChecker.java
+++ b/scalardl-test/src/main/java/scalardl/transfer/TransferChecker.java
@@ -44,8 +44,8 @@ public class TransferChecker extends PostProcessor {
 
   private List<JsonObject> readBalancesWithRetry() {
     logInfo("reading latest assets...");
-    int maxRetry = (int)config.getUserLong("test_config","max_retries_for_read", 10L);
-    long retryIntervalSleepTime = config.getUserLong("test_config","retry_interval_milli_sec",1000L);
+    int maxRetry = (int)config.getUserLong("test_config","checker_max_retries_for_read", 10L);
+    long retryIntervalSleepTime = config.getUserLong("test_config","checker_retry_interval_millis",1000L);
     Retry retry = Common.getRetryWithExponentialBackoff("readBalances", maxRetry, retryIntervalSleepTime);
     Supplier<List<JsonObject>> decorated = Retry.decorateSupplier(retry, this::readBalances);
 

--- a/scalardl-test/src/main/java/scalardl/transfer/TransferChecker.java
+++ b/scalardl-test/src/main/java/scalardl/transfer/TransferChecker.java
@@ -44,7 +44,7 @@ public class TransferChecker extends PostProcessor {
 
   private List<JsonObject> readBalancesWithRetry() {
     logInfo("reading latest assets...");
-
+    Common.setIntervalAndMaxRetry(config);
     Retry retry = Common.getRetryWithExponentialBackoff("readBalances");
     Supplier<List<JsonObject>> decorated = Retry.decorateSupplier(retry, this::readBalances);
 

--- a/scalardl-test/src/main/java/scalardl/transfer/TransferChecker.java
+++ b/scalardl-test/src/main/java/scalardl/transfer/TransferChecker.java
@@ -44,8 +44,9 @@ public class TransferChecker extends PostProcessor {
 
   private List<JsonObject> readBalancesWithRetry() {
     logInfo("reading latest assets...");
-    int maxRetry = (int)config.getUserLong("test_config","checker_max_retries_for_read", 10L);
-    long retryIntervalSleepTime = config.getUserLong("test_config","checker_retry_interval_millis",1000L);
+    int maxRetry = (int) config.getUserLong("test_config", "checker_max_retries_for_read", 10L);
+    long retryIntervalSleepTime =
+        config.getUserLong("test_config", "checker_retry_interval_millis", 1000L);
     Retry retry = Common.getRetryWithExponentialBackoff("readBalances", maxRetry, retryIntervalSleepTime);
     Supplier<List<JsonObject>> decorated = Retry.decorateSupplier(retry, this::readBalances);
 

--- a/scalardl-test/src/main/java/scalardl/transfer/TransferChecker.java
+++ b/scalardl-test/src/main/java/scalardl/transfer/TransferChecker.java
@@ -44,7 +44,7 @@ public class TransferChecker extends PostProcessor {
 
   private List<JsonObject> readBalancesWithRetry() {
     logInfo("reading latest assets...");
-    int maxRetry = (int)config.getUserLong("test_config","max_retry", 10L);
+    int maxRetry = (int)config.getUserLong("test_config","max_retries_for_read", 10L);
     long retryIntervalSleepTime = config.getUserLong("test_config","retry_interval_milli_sec",1000L);
     Retry retry = Common.getRetryWithExponentialBackoff("readBalances", maxRetry, retryIntervalSleepTime);
     Supplier<List<JsonObject>> decorated = Retry.decorateSupplier(retry, this::readBalances);

--- a/scalardl-test/src/main/java/scalardl/transfer/TransferChecker.java
+++ b/scalardl-test/src/main/java/scalardl/transfer/TransferChecker.java
@@ -44,8 +44,9 @@ public class TransferChecker extends PostProcessor {
 
   private List<JsonObject> readBalancesWithRetry() {
     logInfo("reading latest assets...");
-    Common.setIntervalAndMaxRetry(config);
-    Retry retry = Common.getRetryWithExponentialBackoff("readBalances");
+    int maxRetry = (int)config.getUserLong("test_config","max_retry", 10L);
+    long retryIntervalSleepTime = config.getUserLong("test_config","retry_interval_milli_sec",1000L);
+    Retry retry = Common.getRetryWithExponentialBackoff("readBalances", maxRetry, retryIntervalSleepTime);
     Supplier<List<JsonObject>> decorated = Retry.decorateSupplier(retry, this::readBalances);
 
     try {

--- a/scalardl-test/verification-config.toml
+++ b/scalardl-test/verification-config.toml
@@ -16,8 +16,6 @@
   concurrency = 5
   run_for_sec = 900
   ramp_for_sec = 0
-  sleep_base_millis = 1000
-  max_retries = 10
 
 [stats]
   realtime_report_enabled = false
@@ -26,6 +24,8 @@
   is_verification = true
   num_accounts = 10
   population_concurrency = 32
+  retry_interval_milli_sec = 1000
+  max_retries = 10
 
 [storage_config]
   contact_points = "localhost"

--- a/scalardl-test/verification-config.toml
+++ b/scalardl-test/verification-config.toml
@@ -16,7 +16,7 @@
   concurrency = 5
   run_for_sec = 900
   ramp_for_sec = 0
-  sleep_base_millis = 2000
+  sleep_base_millis = 1000
   max_retries = 10
 
 [stats]

--- a/scalardl-test/verification-config.toml
+++ b/scalardl-test/verification-config.toml
@@ -25,7 +25,7 @@
   num_accounts = 10
   population_concurrency = 32
   retry_interval_milli_sec = 1000
-  max_retries = 10
+  max_retries_for_read = 10
 
 [storage_config]
   contact_points = "localhost"

--- a/scalardl-test/verification-config.toml
+++ b/scalardl-test/verification-config.toml
@@ -24,8 +24,8 @@
   is_verification = true
   num_accounts = 10
   population_concurrency = 32
-  retry_interval_milli_sec = 1000
-  max_retries_for_read = 10
+  checker_retry_interval_millis = 1000
+  checker_max_retries_for_read = 10
 
 [storage_config]
   contact_points = "localhost"

--- a/scalardl-test/verification-config.toml
+++ b/scalardl-test/verification-config.toml
@@ -16,6 +16,8 @@
   concurrency = 5
   run_for_sec = 900
   ramp_for_sec = 0
+  sleep_base_millis = 2000
+  max_retries = 10
 
 [stats]
   realtime_report_enabled = false


### PR DESCRIPTION
Changed read retry count and retry interval sleep configurable in the post process check read phase on scalar DL test in kelpie test. This was done on a suggestion to make these values configurable instead of adding a sleep directly.
 This was changed as a fix to "reading records failed repeatedly" issue that has been occurring on daily periodic scalar DL verification test. Added changes to read values from config file during post process read phase to set no of retries as well as the sleep interval between retries to be configurable. This is done to add a 2 second(configurable) delay in each retry to avoid failure of reading data repeatedly. 