### PR TITLE
Batch put in the storage workloads

### DIFF
--- a/scalardb-test/src/main/java/kelpie/scalardb/storage/MultipleClusteringKeyPreparer.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/storage/MultipleClusteringKeyPreparer.java
@@ -21,6 +21,8 @@ import kelpie.scalardb.Common;
 
 public class MultipleClusteringKeyPreparer extends PreProcessor {
 
+  private final int BATCH_SIZE = 20;
+
   private final DistributedStorage storage;
 
   public MultipleClusteringKeyPreparer(Config config) {
@@ -84,7 +86,7 @@ public class MultipleClusteringKeyPreparer extends PreProcessor {
                   Put put = preparePut(pkey, i, j, ThreadLocalRandom.current().nextInt());
                   puts.add(put);
                 }
-                storage.put(puts);
+                StorageCommon.batchPut(storage, puts, BATCH_SIZE);
                 MultipleClusteringKeyPreparer.this.logInfo(
                     "(pkey=" + pkey + ", ckey1=" + i + ") inserted");
               }

--- a/scalardb-test/src/main/java/kelpie/scalardb/storage/SingleClusteringKeyPreparer.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/storage/SingleClusteringKeyPreparer.java
@@ -21,6 +21,8 @@ import kelpie.scalardb.transfer.TransferCommon;
 
 public class SingleClusteringKeyPreparer extends PreProcessor {
 
+  private final int BATCH_SIZE = 20;
+
   private final DistributedStorage storage;
 
   public SingleClusteringKeyPreparer(Config config) {
@@ -83,7 +85,7 @@ public class SingleClusteringKeyPreparer extends PreProcessor {
                 Put put = preparePut(pkey, i, ThreadLocalRandom.current().nextInt());
                 puts.add(put);
               }
-              storage.put(puts);
+              StorageCommon.batchPut(storage, puts, BATCH_SIZE);
               SingleClusteringKeyPreparer.this.logInfo("pkey=" + pkey + " inserted");
             } catch (Exception e) {
               throw new RuntimeException("population failed, retry", e);

--- a/scalardb-test/src/main/java/kelpie/scalardb/storage/StorageCommon.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/storage/StorageCommon.java
@@ -1,6 +1,11 @@
 package kelpie.scalardb.storage;
 
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.Put;
 import com.scalar.db.api.Scan.Ordering.Order;
+import com.scalar.db.exception.storage.ExecutionException;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class StorageCommon {
 
@@ -16,6 +21,21 @@ public final class StorageCommon {
         return Order.ASC;
       default:
         throw new AssertionError("unknown order: " + order);
+    }
+  }
+
+  public static void batchPut(DistributedStorage storage, List<Put> puts, int batchSize)
+      throws ExecutionException {
+    List<Put> buffer = new ArrayList<>(batchSize);
+    for (Put put : puts) {
+      buffer.add(put);
+      if (buffer.size() == batchSize) {
+        storage.put(buffer);
+        buffer.clear();
+      }
+    }
+    if (!buffer.isEmpty()) {
+      storage.put(buffer);
     }
   }
 }


### PR DESCRIPTION
This PR makes the put operations in the storage workloads to the batch put ones because the DynamoDB can't handle more than 35 mutations. Please take a look!