### PR TITLE
Add sensor tests configuration to scalar DB configuration file for daily verification

### DIFF
--- a/scalardb-test/verification-config.toml
+++ b/scalardb-test/verification-config.toml
@@ -1,12 +1,12 @@
 [modules]
   [modules.preprocessor]
-    name = "kelpie.scalardb.transfer.TransferPreparer"
+    name = "kelpie.scalardb.sensor.SensorPreparer"
     path = "build/libs/scalardb-test-all.jar"
   [modules.processor]
-    name = "kelpie.scalardb.transfer.TransferProcessor"
+    name = "kelpie.scalardb.sensor.SensorProcessor"
     path = "build/libs/scalardb-test-all.jar"
   [modules.postprocessor]
-    name = "kelpie.scalardb.transfer.TransferChecker"
+    name = "kelpie.scalardb.sensor.SensorChecker"
     path = "build/libs/scalardb-test-all.jar"
   [[modules.injectors]]
     name = "kelpie.scalardb.injector.CassandraKiller"
@@ -22,16 +22,15 @@
 
 [test_config]
   is_verification = true
-  num_accounts = 10
-  population_concurrency = 8
+  num_devices = 5
 
 [storage_config]
   contact_points = "localhost"
   #username = "cassandra"
   #password = "cassandra"
   #storage = "cassandra"
-  #isolation_level = "SNAPSHOT"
-  #serializable_strategy = "EXTRA_READ"
+  isolation_level = "SERIALIZABLE"
+  serializable_strategy = "EXTRA_READ"
 
 [killer_config]
   ssh_user = "centos"


### PR DESCRIPTION
Added sensor tests configurations to `verification-config.toml` file as this configuration file is used for daily verification scalar DB test execution. 
The same configurations can also be found in [phantom-write-config.toml](https://github.com/scalar-labs/kelpie-test/blob/master/scalardb-test/phantom-write-config.toml). But the verification-config.toml file was updated since we are updating tests to sensor tests and the same file is mentioned in scalar DB kelpie test documentation.
Updated `modules`, `test_config` and `storage_config` sections of the configuration file.