### PR TITLE
Fix to make it work with the 4.0.0-SNAPSHOT

### DIFF
--- a/scalardl-test/build.gradle
+++ b/scalardl-test/build.gradle
@@ -14,6 +14,7 @@ repositories {
 def dockerVersion = project.hasProperty('dockerVersion') ? project.dockerVersion : 'latest'
 
 dependencies {
+    implementation group: 'javax.json', name: 'javax.json-api', version: '1.1.4'
     implementation group: 'com.scalar-labs', name: 'kelpie', version: '1.2.1'
     implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '4.0.0-SNAPSHOT'
     implementation group: 'com.google.inject', name: 'guice', version: '5.0.1'

--- a/scalardl-test/src/main/java/scalardl/transfer/TransferChecker.java
+++ b/scalardl-test/src/main/java/scalardl/transfer/TransferChecker.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.json.Json;
@@ -70,11 +69,7 @@ public class TransferChecker extends PostProcessor {
 
     for (int i = 0; i < numAccounts; i++) {
       try {
-        JsonObject argument =
-            Json.createObjectBuilder()
-                .add("asset_id", String.valueOf(i))
-                .add("nonce", UUID.randomUUID().toString())
-                .build();
+        JsonObject argument = Json.createObjectBuilder().add("asset_id", String.valueOf(i)).build();
 
         JsonObject result = service.executeContract(name, argument).getResult().get();
         results.add(result);

--- a/scalardl-test/src/main/java/scalardl/transfer/TransferPreparer.java
+++ b/scalardl-test/src/main/java/scalardl/transfer/TransferPreparer.java
@@ -1,6 +1,5 @@
 package scalardl.transfer;
 
-import scalardl.Common;
 import com.scalar.dl.client.service.ClientService;
 import com.scalar.kelpie.config.Config;
 import com.scalar.kelpie.exception.PreProcessException;
@@ -9,15 +8,16 @@ import io.github.resilience4j.retry.Retry;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.IntStream;
 import javax.json.Json;
 import javax.json.JsonObject;
+import scalardl.Common;
 
 public class TransferPreparer extends PreProcessor {
+
   private final long POPULATION_CONCURRENCY = 16L;
   private final int NUM_ACCOUNTS_PER_TX = 100;
 
@@ -89,6 +89,7 @@ public class TransferPreparer extends PreProcessor {
   }
 
   private class PopulationRunner implements Runnable {
+
     private final ClientService service;
     private final int threadId;
 
@@ -130,7 +131,6 @@ public class TransferPreparer extends PreProcessor {
               .add("start_id", startId)
               .add("end_id", endId)
               .add("amount", Common.INITIAL_BALANCE)
-              .add("nonce", UUID.randomUUID().toString())
               .build();
       Runnable populate = () -> service.executeContract(populationContractName, argument);
 

--- a/scalardl-test/src/main/java/scalardl/transfer/TransferProcessor.java
+++ b/scalardl-test/src/main/java/scalardl/transfer/TransferProcessor.java
@@ -1,6 +1,5 @@
 package scalardl.transfer;
 
-import scalardl.Common;
 import com.scalar.dl.client.exception.ClientException;
 import com.scalar.dl.client.service.ClientService;
 import com.scalar.dl.ledger.service.StatusCode;
@@ -16,8 +15,10 @@ import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
+import scalardl.Common;
 
 public class TransferProcessor extends TimeBasedProcessor {
+
   private final String transferContractName;
   private final ClientService service;
   private final int numAccounts;
@@ -42,11 +43,11 @@ public class TransferProcessor extends TimeBasedProcessor {
     int amount = ThreadLocalRandom.current().nextInt(1000) + 1;
     JsonObject arg = makeArgument(fromId, toId, amount);
 
-    String txId = arg.getString("nonce");
+    String txId = UUID.randomUUID().toString();
     logStart(txId, fromId, toId, amount);
 
     try {
-      service.executeContract(transferContractName, arg);
+      service.executeContract(txId, transferContractName, arg);
     } catch (Exception e) {
       logFailure(txId, fromId, toId, amount, e);
       throw e;
@@ -74,11 +75,7 @@ public class TransferProcessor extends TimeBasedProcessor {
     JsonArray assetIds =
         Json.createArrayBuilder().add(String.valueOf(fromId)).add(String.valueOf(toId)).build();
 
-    return Json.createObjectBuilder()
-        .add("asset_ids", assetIds)
-        .add("amount", amount)
-        .add("nonce", UUID.randomUUID().toString())
-        .build();
+    return Json.createObjectBuilder().add("asset_ids", assetIds).add("amount", amount).build();
   }
 
   private void logStart(String txId, int fromId, int toId, int amount) {


### PR DESCRIPTION
This PR fixes the recent verification error (invalid analysis).
The cause of the error is that Ledger uses its own nonce (transaction ID) to manage its transaction, whereas clients manage transaction IDs differently and cannot properly trigger read recovery with the client-side transaction IDs (since the client-side transactions IDs don't exist in the server-side).