### PR TITLE
Change read retry count and retry interval sleep made configurable 

### DIFF
--- a/scalardb-test/phantom-write-config.toml
+++ b/scalardb-test/phantom-write-config.toml
@@ -23,7 +23,7 @@
 [test_config]
   is_verification = true
   num_devices = 5
-  checker_retry_interval_millis = 10000
+  checker_retry_interval_millis = 1000
   checker_max_retries_for_read = 10
 
 [storage_config]

--- a/scalardb-test/phantom-write-config.toml
+++ b/scalardb-test/phantom-write-config.toml
@@ -23,6 +23,8 @@
 [test_config]
   is_verification = true
   num_devices = 5
+  checker_retry_interval_millis = 10000
+  checker_max_retries_for_read = 10
 
 [storage_config]
   contact_points = "localhost"

--- a/scalardb-test/src/main/java/kelpie/scalardb/Common.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/Common.java
@@ -132,10 +132,14 @@ public class Common {
   }
 
   public static Retry getRetryWithExponentialBackoff(String name) {
-    IntervalFunction intervalFunc = IntervalFunction.ofExponentialBackoff(SLEEP_BASE_MILLIS, 2.0);
+    return getRetryWithExponentialBackoff(name, MAX_RETRIES, SLEEP_BASE_MILLIS);
+  }
+
+  public static Retry getRetryWithExponentialBackoff(String name, int maxRetries, long waitMillis) {
+    IntervalFunction intervalFunc = IntervalFunction.ofExponentialBackoff(waitMillis, 2.0);
 
     RetryConfig retryConfig =
-        RetryConfig.custom().maxAttempts(MAX_RETRIES).intervalFunction(intervalFunc).build();
+        RetryConfig.custom().maxAttempts(maxRetries).intervalFunction(intervalFunc).build();
 
     return Retry.of(name, retryConfig);
   }

--- a/scalardb-test/src/main/java/kelpie/scalardb/sensor/SensorChecker.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/sensor/SensorChecker.java
@@ -49,7 +49,11 @@ public class SensorChecker extends PostProcessor {
   public void close() {}
 
   private List<Result> readRecordsWithRetry(int timestamp) {
-    Retry retry = Common.getRetryWithExponentialBackoff("readRecords");
+    int maxRetry = (int) config.getUserLong("test_config", "checker_max_retries_for_read", 10L);
+    long retryIntervalSleepTime = config.getUserLong("test_config", "checker_retry_interval_millis",
+        1000L);
+    Retry retry = Common.getRetryWithExponentialBackoff("readBalances", maxRetry,
+        retryIntervalSleepTime);
     Supplier<List<Result>> decorated = Retry.decorateSupplier(retry, () -> readRecords(timestamp));
 
     try {

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/TransferCommon.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/TransferCommon.java
@@ -61,9 +61,13 @@ public class TransferCommon {
   }
 
   public static List<Result> readRecordsWithRetry(Config config) {
+    int maxRetry = (int) config.getUserLong("test_config", "checker_max_retries_for_read", 10L);
+    long retryIntervalSleepTime = config.getUserLong("test_config", "checker_retry_interval_millis",
+        1000L);
     DistributedTransactionManager manager = getTransactionManager(config);
     DistributedStorage storage = getStorage(config);
-    Retry retry = Common.getRetryWithExponentialBackoff("readRecords");
+    Retry retry = Common.getRetryWithExponentialBackoff("readBalances", maxRetry,
+        retryIntervalSleepTime);
     Supplier<List<Result>> decorated =
         Retry.decorateSupplier(retry, () -> readRecords(manager, storage, config));
 

--- a/scalardb-test/verification-config.toml
+++ b/scalardb-test/verification-config.toml
@@ -24,6 +24,8 @@
   is_verification = true
   num_accounts = 10
   population_concurrency = 8
+  checker_retry_interval_millis = 1000
+  checker_max_retries_for_read = 10
 
 [storage_config]
   contact_points = "localhost"


### PR DESCRIPTION
Changed read retry count and retry interval sleep configurable in the post process check read phase on scalar DB test in kelpie test. This change is added to fix an occasional issue of delay in restarting Cassandra nodes before the final read phase. This fix is similar to the [one added](https://github.com/scalar-labs/kelpie-test/pull/45) for scalar DL test for the same issue. 
This issue details and suggested fix details are on the Jira ticket https://scalar-labs.atlassian.net/browse/DLT-11957.
Updated the configuration file for sensor test as currently sensor tests are run on daily scalar DB verification test.

I will create another PR to add configuration changes to the test verification configuration on the verification repository once these changes are merged. 