### PR TITLE
Use exposed json libs instead of importing it in a user-side

### DIFF
--- a/scalardl-test/build.gradle
+++ b/scalardl-test/build.gradle
@@ -14,7 +14,6 @@ repositories {
 def dockerVersion = project.hasProperty('dockerVersion') ? project.dockerVersion : 'latest'
 
 dependencies {
-    implementation group: 'javax.json', name: 'javax.json-api', version: '1.1.4'
     implementation group: 'com.scalar-labs', name: 'kelpie', version: '1.2.1'
     implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '4.0.0-SNAPSHOT'
     implementation group: 'com.google.inject', name: 'guice', version: '5.0.1'


### PR DESCRIPTION

[This commit ](https://github.com/scalar-labs/scalar/pull/807) updated Scalar DL Client to expose the JSON libraries so we can delete the json-api dependency.