### PR TITLE
Fix release workflow failure

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Create scalardb test containers
-        run: ./gradlew docker -PdockerVersion=${{ steps.version.outputs.version }}
+        run: ./gradlew docker -PdockerVersion=${{ steps.version.outputs.version }} -PgprUsername="${{ github.repository_owner }}" -PgprPassword="${{ secrets.CR_PAT }}"
         working-directory: scalardb-test
 
       - name: Create scalardl test containers


### PR DESCRIPTION
After the change in #66, we need to specify a credential for GitHub maven repository to build this. This PR does that in the release workflow. Please take a look!