### PR TITLE
Update base image version of test containers

### DIFF
--- a/scalardb-test/Dockerfile
+++ b/scalardb-test/Dockerfile
@@ -8,7 +8,7 @@ RUN set -x && \
     tar -xzvf "dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz" && \
     ./dockerize --version
 
-FROM openjdk:8u212-jre-slim-stretch
+FROM openjdk:8u342-jre-slim
 
 COPY --from=tools dockerize /usr/local/bin/
 

--- a/scalardl-test/Dockerfile
+++ b/scalardl-test/Dockerfile
@@ -8,7 +8,7 @@ RUN set -x && \
     tar -xzvf "dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz" && \
     ./dockerize --version
 
-FROM openjdk:8u212-jre-slim-stretch
+FROM openjdk:8u342-jre-slim
 
 COPY --from=tools dockerize /usr/local/bin/
 


### PR DESCRIPTION
This PR updates the base image version of the test containers.

In the current Dockerfile, we use `openjdk:8u212-jre-slim-stretch` which uses Debian 9 as a base image, but Debian 9 has already been EoL. At this time, the `apt-get update` command returns an error. It seems that we cannot access some repositories of Debian 9 since it is EoL.

```console
root@6c90245fceb1:/# apt-get update
Ign:1 http://security.debian.org/debian-security stretch/updates InRelease
Ign:2 http://deb.debian.org/debian stretch InRelease
Ign:3 http://security.debian.org/debian-security stretch/updates Release

(snip)

E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.2.132 80]
E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages  404  Not Found
E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found
E: Some index files failed to download. They have been ignored, or old ones used instead.
```

This error causes CI failure. 
https://github.com/scalar-labs/kelpie-test/actions/runs/5065920914/jobs/9095060086

So, I updated the base image from `openjdk:8u212-jre-slim-stretch` to `openjdk:8u342-jre-slim`. The base image of `openjdk:8u342-jre-slim` is Debian 11 which is the supported version. So, we can run the `apt-get` command properly.

Also, I think we have several options to resolve the CI issue as follows.

* Use `openjdk:8u342-jre-slim` -> Always use the `latest` Debian as a base image (i.e., it automatically updates from Debian 11 to Debian 12 in the future).
* Use `openjdk:8u342-jre-slim-buster` -> Use Debian 10 as a base image (i.e., use a fixed version)
* Use `openjdk:8u342-jre-slim-bullseye` -> Use Debian 11 as a base image (i.e., use a fixed version).

I chose `openjdk:8u342-jre-slim` since I didn't come up with any reasons that we want to make the Debian version fixed.

However, I'm not familiar with kelpie. So, I want to ask you whether you have any concerns to use the latest Debian (11 at the moment).
Do you have any concerns? 
If yes, I can update this PR to use the fixed version (Debian 10 or 11).

Please take a look!

---

For your reference, I confirmed that I can build test container images in my local environment by using `openjdk:8u342-jre-slim` as follows.

<details>

<summary>Build test container for ScalarDB</summary>

```shell
$ ./gradlew docker -PdockerVersion=test -PgprUsername="${GITHUB_USER}" -PgprPassword="${GITHUB_PAT}"

> Task :compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

> Task :docker
#1 [internal] load .dockerignore
#1 transferring context: 2B done
#1 DONE 0.1s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 1.25kB done
#2 DONE 0.1s

#3 [internal] load metadata for docker.io/library/openjdk:8u342-jre-slim
#3 DONE 0.0s

#4 [internal] load metadata for docker.io/library/busybox:1.32
#4 DONE 1.6s

#5 [stage-1 1/8] FROM docker.io/library/openjdk:8u342-jre-slim
#5 DONE 0.0s

#6 [internal] load build context
#6 ...

#7 [tools 1/2] FROM docker.io/library/busybox:1.32@sha256:ae39a6f5c07297d7ab64dbd4f82c77c874cc6a94cea29fdec309d0992574b4f7
#7 resolve docker.io/library/busybox:1.32@sha256:ae39a6f5c07297d7ab64dbd4f82c77c874cc6a94cea29fdec309d0992574b4f7 0.1s done
#7 DONE 0.1s

#6 [internal] load build context
#6 transferring context: 109.20MB 0.6s done
#6 DONE 0.6s

#8 [tools 2/2] RUN set -x &&     wget -q "https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz" &&     tar -xzvf "dockerize-linux-amd64-v0.6.1.tar.gz" &&     ./dockerize --version
#8 CACHED

#9 [stage-1 2/8] COPY --from=tools dockerize /usr/local/bin/
#9 CACHED

#10 [stage-1 3/8] RUN apt-get update && apt-get install wget unzip -y &&     wget -O /tmp/kelpie.zip https://github.com/scalar-labs/kelpie/releases/download/1.2.0/kelpie-1.2.0.zip &&     unzip /tmp/kelpie.zip &&     mv /kelpie-1.2.0/bin/kelpie /usr/local/bin/kelpie &&     mv /kelpie-1.2.0/lib/* /usr/local/lib/ &&     rm -rf /tmp/kelpie.zip kelpie-1.2.0 /var/lib/apt/lists/*
#10 CACHED

#11 [stage-1 4/8] WORKDIR /scalardb/kelpie
#11 CACHED

#12 [stage-1 5/8] RUN mkdir -p scalardb-test/build/libs/
#12 CACHED

#13 [stage-1 6/8] COPY scalardb-test-all.jar scalardb-test/build/libs/
#13 DONE 3.5s

#14 [stage-1 7/8] WORKDIR /scalardb/kelpie/scalardb-test
#14 DONE 0.1s

#15 [stage-1 8/8] COPY grpc-config.toml.tmpl grpc-config.toml.tmpl
#15 DONE 0.3s

#16 exporting to image
#16 exporting layers
#16 exporting layers 0.6s done
#16 writing image sha256:799f362ff38efd827a9ba6a6630b6e35893192ba2fb5550eb34680f27d38d2eb done
#16 naming to ghcr.io/scalar-labs/kelpie-test-scalardb:test done
#16 DONE 0.6s

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.7/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 17s
5 actionable tasks: 4 executed, 1 up-to-date
```
</details>

<details>

<summary>Build test container for ScalarDL</summary>

```shell
$ ./gradlew docker -PdockerVersion=test

> Task :compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

> Task :docker
#1 [internal] load .dockerignore
#1 transferring context: 2B done
#1 DONE 0.0s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 1.32kB done
#2 DONE 0.1s

#3 [internal] load metadata for docker.io/library/openjdk:8u342-jre-slim
#3 DONE 0.0s

#4 [internal] load metadata for docker.io/library/busybox:1.32
#4 DONE 0.7s

#5 [internal] load build context
#5 DONE 0.0s

#6 [stage-1  1/10] FROM docker.io/library/openjdk:8u342-jre-slim
#6 DONE 0.0s

#7 [tools 1/2] FROM docker.io/library/busybox:1.32@sha256:ae39a6f5c07297d7ab64dbd4f82c77c874cc6a94cea29fdec309d0992574b4f7
#7 resolve docker.io/library/busybox:1.32@sha256:ae39a6f5c07297d7ab64dbd4f82c77c874cc6a94cea29fdec309d0992574b4f7 0.1s done
#7 DONE 0.1s

#8 [stage-1  2/10] COPY --from=tools dockerize /usr/local/bin/
#8 CACHED

#9 [tools 2/2] RUN set -x &&     wget -q "https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz" &&     tar -xzvf "dockerize-linux-amd64-v0.6.1.tar.gz" &&     ./dockerize --version
#9 CACHED

#10 [stage-1  3/10] RUN apt-get update && apt-get install wget unzip -y &&     wget -O /tmp/kelpie.zip https://github.com/scalar-labs/kelpie/releases/download/1.2.0/kelpie-1.2.0.zip &&     unzip /tmp/kelpie.zip &&     mv /kelpie-1.2.0/bin/kelpie /usr/local/bin/kelpie &&     mv /kelpie-1.2.0/lib/* /usr/local/lib/ &&     rm -rf /tmp/kelpie.zip kelpie-1.2.0 /var/lib/apt/lists/*
#10 CACHED

#5 [internal] load build context
#5 ...

#11 [stage-1  4/10] WORKDIR /scalar/kelpie
#11 DONE 1.0s

#5 [internal] load build context
#5 transferring context: 77.35MB 1.2s done
#5 DONE 1.3s

#12 [stage-1  5/10] RUN mkdir -p scalardl-test/build/libs/
#12 DONE 1.5s

#13 [stage-1  6/10] COPY build/classes scalardl-test/build/classes
#13 DONE 0.1s

#14 [stage-1  7/10] COPY scalardl-test-all.jar scalardl-test/build/libs/
#14 DONE 0.9s

#15 [stage-1  8/10] COPY sample-keys scalardl-test/sample-keys
#15 DONE 0.1s

#16 [stage-1  9/10] COPY config.toml.tmpl scalardl-test/config.toml.tmpl
#16 DONE 0.1s

#17 [stage-1 10/10] WORKDIR /scalar/kelpie/scalardl-test
#17 DONE 0.1s

#18 exporting to image
#18 exporting layers
#18 exporting layers 0.6s done
#18 writing image sha256:d0766791fae29e18940256aecf59bc29a13db47673258941109d45f21ee7570e done
#18 naming to ghcr.io/scalar-labs/kelpie-test-scalardl:test done
#18 DONE 0.6s

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.7/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 13s
5 actionable tasks: 4 executed, 1 up-to-date
```
</details>

```shell
$ docker image ls
REPOSITORY                                  TAG     IMAGE ID       CREATED         SIZE
ghcr.io/scalar-labs/kelpie-test-scalardl    test    d0766791fae2   2 minutes ago   288MB
ghcr.io/scalar-labs/kelpie-test-scalardb    test    799f362ff38e   3 minutes ago   320MB
```
