### PR TITLE
Upgrade shadowJar plugin

### DIFF
--- a/scalardb-test/build.gradle
+++ b/scalardb-test/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library-distribution'
-    id "com.github.johnrengelman.shadow" version "5.2.0"
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
     id 'com.palantir.docker' version '0.25.0'
 }
 

--- a/scalardl-test/build.gradle
+++ b/scalardl-test/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library-distribution'
-    id "com.github.johnrengelman.shadow" version "5.2.0"
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
     id 'com.palantir.docker' version '0.25.0'
 }
 


### PR DESCRIPTION
This PR upgrades the `shadowJar` plugin to `7.1.2`. Please take a look!