### PR TITLE
Add zip64 option to shardowjar task in scalardb-test

### DIFF
--- a/scalardb-test/build.gradle
+++ b/scalardb-test/build.gradle
@@ -58,6 +58,7 @@ dependencies {
 
 shadowJar {
     mergeServiceFiles()
+    zip64 true
 }
 
 docker {


### PR DESCRIPTION
## Description

We are facing the following error when building `shardowjar` in `scalardb-test`.

```
> shadow.org.apache.tools.zip.Zip64RequiredException: archive contains more than 65535 entries.
```

To address this issue, this PR adds the `zip64` option to the `shardowjar` task in `scalardb-test`.

## Related issues and/or PRs

N/A

## Changes made

- Added the `zip64` option to the `shardowjar` task in `scalardb-test`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The same issue is explained in the following issue:
https://github.com/johnrengelman/shadow/issues/107
