### PR TITLE
Remove ScalarDB `api` dependency

### DIFF
--- a/scalardl-test/build.gradle
+++ b/scalardl-test/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     implementation group: 'com.scalar-labs', name: 'kelpie', version: '1.2.3'
     implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '4.0.0-SNAPSHOT'
     implementation group: 'com.google.inject', name: 'guice', version: '5.0.1'
-    api group: 'com.scalar-labs', name: 'scalardb', version: '4.0.0-SNAPSHOT'
     implementation group: "io.github.resilience4j", name: "resilience4j-retry", version: "1.3.1"
 }
 


### PR DESCRIPTION
## Description

This PR removes ScalarDB `api` dependency due to the following reasons.

- Client SDK now exposes the ScalarDB library, so we don't have to do it here.
- Potentially, it causes a version mismatch of libraries since ScalarDL (4.0.0-SNAPSHOT) uses a different ScalarDB version (e.g., 3.13.0 now).

## Related issues and/or PRs

- #13

I guess we needed the dependency because ScalarDL Client SDK doesn't expose the ScalarDB library at that moment.

## Changes made

- Remove ScalarDB `api` dependency.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
