### PR TITLE
Remove serializable strategy configs

### DIFF
--- a/scalardb-test/benchmark-config.toml
+++ b/scalardb-test/benchmark-config.toml
@@ -27,7 +27,6 @@
   #password = "cassandra"
   #storage = "cassandra"
   #isolation_level = "SNAPSHOT"
-  #serializable_strategy = "EXTRA_READ"
 
 [killer_config]
   ssh_user = "centos"

--- a/scalardb-test/phantom-write-config.toml
+++ b/scalardb-test/phantom-write-config.toml
@@ -32,7 +32,6 @@
   #password = "cassandra"
   #storage = "cassandra"
   isolation_level = "SERIALIZABLE"
-  serializable_strategy = "EXTRA_READ"
 
 [killer_config]
   ssh_user = "centos"

--- a/scalardb-test/src/main/java/kelpie/scalardb/Common.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/Common.java
@@ -81,8 +81,6 @@ public class Common {
     String isolationLevel = config.getUserString("storage_config", "isolation_level", "SNAPSHOT");
     String transactionManager =
         config.getUserString("storage_config", "transaction_manager", "consensus-commit");
-    String serializableStrategy =
-        config.getUserString("storage_config", "serializable_strategy", "EXTRA_READ");
 
     Properties props = new Properties();
     props.setProperty("scalar.db.contact_points", contactPoints);
@@ -94,7 +92,6 @@ public class Common {
     props.setProperty("scalar.db.storage", storage);
     props.setProperty("scalar.db.transaction_manager", transactionManager);
     props.setProperty("scalar.db.isolation_level", isolationLevel);
-    props.setProperty("scalar.db.consensus_commit.serializable_strategy", serializableStrategy);
     return new DatabaseConfig(props);
   }
 

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferChecker.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferChecker.java
@@ -12,13 +12,9 @@ import javax.json.JsonObject;
 import kelpie.scalardb.Common;
 
 public class WriteSkewTransferChecker extends PostProcessor {
-  private final boolean isSerializable;
-  private final boolean isExtraRead;
 
   public WriteSkewTransferChecker(Config config) {
     super(config);
-    this.isSerializable = config.getUserBoolean("test_config", "is_serializable", false);
-    this.isExtraRead = config.getUserBoolean("test_config", "is_extra_read", false);
   }
 
   @Override
@@ -41,7 +37,8 @@ public class WriteSkewTransferChecker extends PostProcessor {
   }
 
   @Override
-  public void close() {}
+  public void close() {
+  }
 
   private int getNumOfUpdatesFromCoordinator(Config config) {
     Coordinator coordinator = new Coordinator(Common.getStorage(config));
@@ -73,15 +70,7 @@ public class WriteSkewTransferChecker extends PostProcessor {
                 + ","
                 + toType
                 + " succeeded, not failed");
-        if (isSerializable && !isExtraRead) {
-          if (fromId != toId) {
-            numUpdates += TransferCommon.NUM_TYPES + 1;
-          } else {
-            numUpdates += TransferCommon.NUM_TYPES;
-          }
-        } else {
-          numUpdates += 2;
-        }
+        numUpdates += 2;
       }
     }
 

--- a/scalardb-test/verification-config.toml
+++ b/scalardb-test/verification-config.toml
@@ -33,7 +33,6 @@
   #password = "cassandra"
   #storage = "cassandra"
   #isolation_level = "SNAPSHOT"
-  #serializable_strategy = "EXTRA_READ"
 
 [killer_config]
   ssh_user = "centos"

--- a/scalardb-test/write-skew-config.toml
+++ b/scalardb-test/write-skew-config.toml
@@ -22,8 +22,6 @@
 
 [test_config]
   is_verification = true
-  is_serializable = false
-  is_extra_read = false
   num_accounts = 10
   population_concurrency = 8
 
@@ -33,7 +31,6 @@
   #password = "cassandra"
   #storage = "cassandra"
   isolation_level = "SERIALIZABLE"
-  serializable_strategy = "EXTRA_READ"
 
 [killer_config]
   ssh_user = "centos"


### PR DESCRIPTION
## Description

This PR removes serializable strategy configs, as it was removed in https://github.com/scalar-labs/scalardb/pull/2597.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2597

## Changes made


## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
