### PR TITLE
Use Scanner API in Sensor workload

### DIFF
--- a/scalardb-test/schema/tx_sensor.cql
+++ b/scalardb-test/schema/tx_sensor.cql
@@ -2,6 +2,7 @@ DROP KEYSPACE IF EXISTS sensor;
 CREATE KEYSPACE IF NOT EXISTS sensor WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };
 DROP KEYSPACE IF EXISTS coordinator;
 CREATE KEYSPACE IF NOT EXISTS coordinator WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };
+CREATE KEYSPACE IF NOT EXISTS scalardb WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };
 
 CREATE TABLE IF NOT EXISTS sensor.tx_sensor (
     timestamp int,
@@ -27,3 +28,10 @@ CREATE TABLE IF NOT EXISTS coordinator.state (
     tx_created_at bigint,
     PRIMARY KEY (tx_id)
 );
+
+CREATE TABLE IF NOT EXISTS scalardb.namespaces (
+    name text,
+    PRIMARY KEY (name)
+);
+
+INSERT INTO scalardb.namespaces (name) VALUES ('sensor');

--- a/scalardb-test/schema/tx_sensor.cql
+++ b/scalardb-test/schema/tx_sensor.cql
@@ -35,3 +35,5 @@ CREATE TABLE IF NOT EXISTS scalardb.namespaces (
 );
 
 INSERT INTO scalardb.namespaces (name) VALUES ('sensor');
+INSERT INTO scalardb.namespaces (name) VALUES ('coordinator');
+INSERT INTO scalardb.namespaces (name) VALUES ('scalardb');

--- a/scalardb-test/src/main/java/kelpie/scalardb/sensor/SensorChecker.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/sensor/SensorChecker.java
@@ -40,7 +40,7 @@ public class SensorChecker extends PostProcessor {
     }
 
     if (isDuplicated) {
-      logError("dupilication happened !");
+      logError("Duplication happened !");
       throw new PostProcessException("Inconsistency happened!");
     }
   }

--- a/scalardb-test/src/main/java/kelpie/scalardb/sensor/SensorCommon.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/sensor/SensorCommon.java
@@ -55,7 +55,7 @@ public class SensorCommon {
     return maxRevision.orElse(0);
   }
 
-  private static int getRevisionFromResult(Result result) {
+  public static int getRevisionFromResult(Result result) {
     return result.getInt(REVISION);
   }
 }

--- a/scalardb-test/src/main/java/kelpie/scalardb/sensor/SensorProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/sensor/SensorProcessor.java
@@ -78,6 +78,8 @@ public class SensorProcessor extends TimeBasedProcessor {
 
     boolean hasDuplicatedRevision;
     List<Result> results;
+
+    // Alternate between scan() and getScanner() based on the attempt count.
     boolean scannerUsed = numAttempts.getAndIncrement() % 2 == 0;
     if (!scannerUsed) {
       // Use scan()


### PR DESCRIPTION
## Description

This PR updates the sensor workload to use the scanner API introduced in https://github.com/scalar-labs/scalardb/pull/2729.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2729

## Changes made

- Updated the sensor workload to use the scanner API

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
