### PR TITLE
Fix tx_transfer.cql

### DIFF
--- a/scalardb-test/schema/tx_sensor.cql
+++ b/scalardb-test/schema/tx_sensor.cql
@@ -2,6 +2,7 @@ DROP KEYSPACE IF EXISTS sensor;
 CREATE KEYSPACE IF NOT EXISTS sensor WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };
 DROP KEYSPACE IF EXISTS coordinator;
 CREATE KEYSPACE IF NOT EXISTS coordinator WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };
+DROP KEYSPACE IF EXISTS scalardb;
 CREATE KEYSPACE IF NOT EXISTS scalardb WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };
 
 CREATE TABLE IF NOT EXISTS sensor.tx_sensor (

--- a/scalardb-test/schema/tx_transfer.cql
+++ b/scalardb-test/schema/tx_transfer.cql
@@ -1,6 +1,9 @@
 DROP KEYSPACE IF EXISTS transfer;
 CREATE KEYSPACE IF NOT EXISTS transfer WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };
+DROP KEYSPACE IF EXISTS coordinator;
 CREATE KEYSPACE IF NOT EXISTS coordinator WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };
+DROP KEYSPACE IF EXISTS scalardb;
+CREATE KEYSPACE IF NOT EXISTS scalardb WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };
 
 CREATE TABLE IF NOT EXISTS transfer.tx_transfer (
     account_id int,
@@ -26,3 +29,12 @@ CREATE TABLE IF NOT EXISTS coordinator.state (
     tx_created_at bigint,
     PRIMARY KEY (tx_id)
 );
+
+CREATE TABLE IF NOT EXISTS scalardb.namespaces (
+    name text,
+    PRIMARY KEY (name)
+);
+
+INSERT INTO scalardb.namespaces (name) VALUES ('transfer');
+INSERT INTO scalardb.namespaces (name) VALUES ('coordinator');
+INSERT INTO scalardb.namespaces (name) VALUES ('scalardb');


### PR DESCRIPTION
## Description

This PR fixes `tx_transfer.cql` to create the `scalardb.namespaces` table, which was introduced in version `4.0.0`.

## Related issues and/or PRs

N/A

## Changes made

> Outline the specific changes made in this pull request. Include relevant details, such as added features, bug fixes, code refactoring, or improvements.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
