### PR TITLE
Add tx_child_ids column to coordinator table

### DIFF
--- a/scalardb-test/schema/tx_sensor.cql
+++ b/scalardb-test/schema/tx_sensor.cql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS sensor.tx_sensor (
 
 CREATE TABLE IF NOT EXISTS coordinator.state (
     tx_id text,
+    tx_child_ids text,
     tx_state int,
     tx_created_at bigint,
     PRIMARY KEY (tx_id)

--- a/scalardb-test/schema/tx_transfer.cql
+++ b/scalardb-test/schema/tx_transfer.cql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS transfer.tx_transfer (
 
 CREATE TABLE IF NOT EXISTS coordinator.state (
     tx_id text,
+    tx_child_ids text,
     tx_state int,
     tx_created_at bigint,
     PRIMARY KEY (tx_id)


### PR DESCRIPTION
## Description

Starting from ScalarDB 4.0.0 (which has not been released yet), the `coordinator` table should include the `tx_child_ids` column. However, the schema CQL files used for the verification tests do not contain this column.  

To address this issue, this PR adds the `tx_child_ids` column to the `coordinator` table in the schema CQL files.

## Related issues and/or PRs

N/A

## Changes made

- Added the `tx_child_ids` column to the `coordinator` table.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
