### PR TITLE
Add zip64 option to  to shadowJar task in scalardl-test

### DIFF
--- a/scalardl-test/build.gradle
+++ b/scalardl-test/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 shadowJar {
     mergeServiceFiles()
     exclude 'contract/*'
+    zip64 true
 }
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
## Description

The following error when building shadowJar in scalardl-test on [benchmark tests](https://github.com/scalar-labs/verification/actions/runs/19898356461/job/57034789208#step:10:46) and [verification test for scalardl.](https://github.com/scalar-labs/verification/actions/runs/19890232990/job/57006986912#step:9:46)
```
> shadow.org.apache.tools.zip.Zip64RequiredException: archive contains more than 65535 entries.
```
To address this issue, this PR adds the zip64 option to the shadowJar task in scalardl-test.

This fix was already added on scalardb-test in https://github.com/scalar-labs/kelpie-test/pull/86 as same issue before.

## Related issues and/or PRs

NA

## Changes made

* Added the `zip64` option to the `shardowJar` task in scalardl-test.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

NA
