### PR TITLE
Added auto bootstrap property in scalardl config

### DIFF
--- a/scalardl-test/src/main/java/scalardl/Common.java
+++ b/scalardl-test/src/main/java/scalardl/Common.java
@@ -56,9 +56,8 @@ public class Common {
 
   public static ClientService getClientService(Config config) {
     ClientConfig clientConfig = getClientConfig(config);
-    ClientServiceFactory factory = new ClientServiceFactory(clientConfig);
-
-    return factory.getClientService();
+    ClientServiceFactory factory = new ClientServiceFactory();
+    return factory.create(clientConfig);
   }
 
   public static int getTotalInitialBalance(Config config) {

--- a/scalardl-test/src/main/java/scalardl/Common.java
+++ b/scalardl-test/src/main/java/scalardl/Common.java
@@ -43,6 +43,7 @@ public class Common {
     properties.setProperty(ClientConfig.CERT_HOLDER_ID, CERT_HOLDER_ID);
     properties.setProperty(ClientConfig.CERT_PATH, certificate);
     properties.setProperty(ClientConfig.PRIVATE_KEY_PATH, privateKey);
+    properties.setProperty(ClientConfig.AUTO_BOOTSTRAP, "false");
 
     ClientConfig clientConfig = null;
     try {


### PR DESCRIPTION
## Description

The scalardl verification test failed due to `com.scalar.dl.client.exception.ClientException: DL-COMMON-405001: The specified certificate is already registered.` which was caused by changes made in PR https://github.com/scalar-labs/scalardl/pull/370. I have added a fix suggested by @jnmt san in this [comment](https://scalar-labs.atlassian.net/browse/DLT-17996?focusedCommentId=29620). I have applied one of the suggested fixes to set auto bootstrap to false.
Bug ticket for reference:  https://scalar-labs.atlassian.net/browse/DLT-17996
I have tested and confirmed fix in my local environment.

## Related issues and/or PRs

NA

## Changes made

I have added `ClientConfig.AUTO_BOOTSTRAP` to scalardl client properties and set is to false.
I have also updated `ClientServiceFactory` and `ClientService` creation to new method from deprecated ones as this was discussed as part for the fix.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

NA
