### PR TITLE
Replace Apache Commons DBCP2 with HikariCP in scalardb tests

### DIFF
--- a/scalardb-test/build.gradle
+++ b/scalardb-test/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation 'com.azure:azure-cosmos:4.64.0'
     implementation "software.amazon.awssdk:dynamodb:${awssdkVersion}"
     implementation "software.amazon.awssdk:core:${awssdkVersion}"
-    implementation 'org.apache.commons:commons-dbcp2:2.12.0'
+    implementation 'com.zaxxer:HikariCP:4.0.3'
     implementation "com.scalar-labs:scalardb-sql-direct-mode:${scalarDbVersion}"
     implementation "com.scalar-labs:scalardb-sql-jdbc:${scalarDbVersion}"
     implementation "com.scalar-labs:scalardb-graphql:${scalarDbVersion}"

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/jdbc/NontransactionalTransferProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/jdbc/NontransactionalTransferProcessor.java
@@ -7,6 +7,7 @@ import com.scalar.db.storage.jdbc.RdbEngineFactory;
 import com.scalar.db.storage.jdbc.RdbEngineStrategy;
 import com.scalar.kelpie.config.Config;
 import com.scalar.kelpie.modules.TimeBasedProcessor;
+import com.zaxxer.hikari.HikariDataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -14,11 +15,10 @@ import java.sql.SQLException;
 import java.util.concurrent.ThreadLocalRandom;
 import kelpie.scalardb.Common;
 import kelpie.scalardb.transfer.TransferCommon;
-import org.apache.commons.dbcp2.BasicDataSource;
 
 public class NontransactionalTransferProcessor extends TimeBasedProcessor {
   private final int numAccounts;
-  private final BasicDataSource dataSource;
+  private final HikariDataSource dataSource;
   private final RdbEngineStrategy rdbEngine;
 
   public NontransactionalTransferProcessor(Config config) {
@@ -42,11 +42,7 @@ public class NontransactionalTransferProcessor extends TimeBasedProcessor {
 
   @Override
   public void close() {
-    try {
-      dataSource.close();
-    } catch (SQLException e) {
-      throw new RuntimeException("fail to close the dataSource", e);
-    }
+    dataSource.close();
   }
 
   private void transfer(int fromId, int toId, int amount) throws SQLException {

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/sql/SqlCommon.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/sql/SqlCommon.java
@@ -4,7 +4,8 @@ import com.scalar.db.sql.SqlConfig;
 import com.scalar.db.sql.SqlSessionFactory;
 import com.scalar.db.sql.TransactionMode;
 import com.scalar.kelpie.config.Config;
-import org.apache.commons.dbcp2.BasicDataSource;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 
 public final class SqlCommon {
 
@@ -34,39 +35,36 @@ public final class SqlCommon {
         .build();
   }
 
-  public static BasicDataSource getDataSource(Config config, TransactionMode transactionMode) {
+  public static HikariDataSource getDataSource(Config config, TransactionMode transactionMode) {
     return getDataSource(config, transactionMode, "config_file");
   }
 
-  public static BasicDataSource getDataSource1(Config config, TransactionMode transactionMode) {
+  public static HikariDataSource getDataSource1(Config config, TransactionMode transactionMode) {
     return getDataSource(config, transactionMode, "config_file1");
   }
 
-  public static BasicDataSource getDataSource2(Config config, TransactionMode transactionMode) {
+  public static HikariDataSource getDataSource2(Config config, TransactionMode transactionMode) {
     return getDataSource(config, transactionMode, "config_file2");
   }
 
-  private static BasicDataSource getDataSource(
+  private static HikariDataSource getDataSource(
       Config config, TransactionMode transactionMode, String configName) {
     String configFile = config.getUserString("sql_config", configName);
 
-    BasicDataSource dataSource = new BasicDataSource();
-    dataSource.setDriver(new com.scalar.db.Driver());
-    dataSource.setUrl(
+    HikariConfig hikariConfig = new HikariConfig();
+    hikariConfig.setDriverClassName("com.scalar.db.Driver");
+    hikariConfig.setJdbcUrl(
         "jdbc:scalardb:"
             + configFile
             + "?"
             + SqlConfig.DEFAULT_TRANSACTION_MODE
             + "="
             + transactionMode.name());
-    dataSource.setDefaultAutoCommit(false);
-    dataSource.setAutoCommitOnReturn(false);
-    dataSource.setMinIdle(
+    hikariConfig.setAutoCommit(false);
+    hikariConfig.setMinimumIdle(
         (int) config.getUserLong("sql_config", "jdbc_connection_pool_min_idle", 20L));
-    dataSource.setMaxIdle(
-        (int) config.getUserLong("sql_config", "jdbc_connection_pool_max_idle", 50L));
-    dataSource.setMaxTotal(
+    hikariConfig.setMaximumPoolSize(
         (int) config.getUserLong("sql_config", "jdbc_connection_pool_max_total", 200L));
-    return dataSource;
+    return new HikariDataSource(hikariConfig);
   }
 }

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/sql/jdbc/TransferPreparer.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/sql/jdbc/TransferPreparer.java
@@ -3,6 +3,7 @@ package kelpie.scalardb.transfer.sql.jdbc;
 import com.scalar.db.sql.TransactionMode;
 import com.scalar.kelpie.config.Config;
 import com.scalar.kelpie.modules.PreProcessor;
+import com.zaxxer.hikari.HikariDataSource;
 import io.github.resilience4j.retry.Retry;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -16,7 +17,6 @@ import java.util.stream.IntStream;
 import kelpie.scalardb.Common;
 import kelpie.scalardb.transfer.TransferCommon;
 import kelpie.scalardb.transfer.sql.SqlCommon;
-import org.apache.commons.dbcp2.BasicDataSource;
 
 public class TransferPreparer extends PreProcessor {
   private static final long DEFAULT_POPULATION_CONCURRENCY = 32L;
@@ -24,7 +24,7 @@ public class TransferPreparer extends PreProcessor {
   private static final long DEFAULT_POPULATION_MAX_RETRIES = 10;
   private static final long DEFAULT_POPULATION_WAIT_MILLS = 1000;
 
-  private final BasicDataSource dataSource;
+  private final HikariDataSource dataSource;
 
   public TransferPreparer(Config config) {
     super(config);
@@ -55,11 +55,7 @@ public class TransferPreparer extends PreProcessor {
 
   @Override
   public void close() {
-    try {
-      dataSource.close();
-    } catch (SQLException e) {
-      logWarn("Failed to close DataSource", e);
-    }
+    dataSource.close();
   }
 
   private class PopulationRunner {

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/sql/jdbc/TransferProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/sql/jdbc/TransferProcessor.java
@@ -3,6 +3,7 @@ package kelpie.scalardb.transfer.sql.jdbc;
 import com.scalar.db.sql.TransactionMode;
 import com.scalar.kelpie.config.Config;
 import com.scalar.kelpie.modules.TimeBasedProcessor;
+import com.zaxxer.hikari.HikariDataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -10,11 +11,10 @@ import java.sql.SQLException;
 import java.util.concurrent.ThreadLocalRandom;
 import kelpie.scalardb.transfer.TransferCommon;
 import kelpie.scalardb.transfer.sql.SqlCommon;
-import org.apache.commons.dbcp2.BasicDataSource;
 
 public class TransferProcessor extends TimeBasedProcessor {
   private final int numAccounts;
-  private final BasicDataSource dataSource;
+  private final HikariDataSource dataSource;
 
   public TransferProcessor(Config config) {
     super(config);
@@ -35,11 +35,7 @@ public class TransferProcessor extends TimeBasedProcessor {
 
   @Override
   public void close() {
-    try {
-      dataSource.close();
-    } catch (SQLException e) {
-      logWarn("Failed to close DataSource", e);
-    }
+    dataSource.close();
   }
 
   private void transfer(Connection connection, int fromId, int toId, int amount)

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/sql/jdbc/TransferWithTwoPhaseCommitTransactionProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/sql/jdbc/TransferWithTwoPhaseCommitTransactionProcessor.java
@@ -3,6 +3,7 @@ package kelpie.scalardb.transfer.sql.jdbc;
 import com.scalar.db.sql.TransactionMode;
 import com.scalar.kelpie.config.Config;
 import com.scalar.kelpie.modules.TimeBasedProcessor;
+import com.zaxxer.hikari.HikariDataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -11,12 +12,11 @@ import java.sql.Statement;
 import java.util.concurrent.ThreadLocalRandom;
 import kelpie.scalardb.transfer.TransferCommon;
 import kelpie.scalardb.transfer.sql.SqlCommon;
-import org.apache.commons.dbcp2.BasicDataSource;
 
 public class TransferWithTwoPhaseCommitTransactionProcessor extends TimeBasedProcessor {
   private final int numAccounts;
-  private final BasicDataSource dataSource1;
-  private final BasicDataSource dataSource2;
+  private final HikariDataSource dataSource1;
+  private final HikariDataSource dataSource2;
 
   public TransferWithTwoPhaseCommitTransactionProcessor(Config config) {
     super(config);
@@ -39,17 +39,8 @@ public class TransferWithTwoPhaseCommitTransactionProcessor extends TimeBasedPro
 
   @Override
   public void close() {
-    try {
-      dataSource1.close();
-    } catch (SQLException e) {
-      logWarn("Failed to close DataSource", e);
-    }
-
-    try {
-      dataSource2.close();
-    } catch (SQLException e) {
-      logWarn("Failed to close DataSource", e);
-    }
+    dataSource1.close();
+    dataSource2.close();
   }
 
   private void transfer(


### PR DESCRIPTION
## Description

This PR replaces Apache Commons DBCP2 with HikariCP for connection pooling in ScalarDB tests. ScalarDB has migrated from DBCP2 to HikariCP for connection pooling (https://github.com/scalar-labs/scalardb/pull/3305). This change aligns `kelpie-test` with ScalarDB to maintain consistency.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/3305

## Changes made

- Update `SqlCommon.java` to use `HikariDataSource` and `HikariConfig` instead of `BasicDataSource`
- Migrate connection pool configuration from DBCP2 API to HikariCP API:
  - `setDriver()` → `setDriverClassName()`
  - `setUrl()` → `setJdbcUrl()`
  - `setDefaultAutoCommit()` → `setAutoCommit()`
  - `setMinIdle()` → `setMinimumIdle()`
  - `setMaxTotal()` → `setMaximumPoolSize()`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
