### PR TITLE
Adapt to new PreparedStatement API with bind() and BoundStatement

### DIFF
--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/sql/TransferPreparer.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/sql/TransferPreparer.java
@@ -4,7 +4,7 @@ import com.scalar.db.sql.PreparedStatement;
 import com.scalar.db.sql.SqlSession;
 import com.scalar.db.sql.SqlSessionFactory;
 import com.scalar.db.sql.TransactionMode;
-import com.scalar.db.sql.Value;
+import com.scalar.db.sql.statement.BoundStatement;
 import com.scalar.kelpie.config.Config;
 import com.scalar.kelpie.modules.PreProcessor;
 import io.github.resilience4j.retry.Retry;
@@ -109,11 +109,11 @@ public class TransferPreparer extends PreProcessor {
 
                 for (int i = startId; i < endId; ++i) {
                   for (int j = 0; j < TransferCommon.NUM_TYPES; ++j) {
-                    preparedStatement.clearParameters();
-                    preparedStatement.set(0, Value.ofInt(i));
-                    preparedStatement.set(1, Value.ofInt(j));
-                    preparedStatement.set(2, Value.ofInt(TransferCommon.INITIAL_BALANCE));
-                    preparedStatement.execute();
+                    BoundStatement boundStatement = preparedStatement.bind();
+                    boundStatement.setInt(0, i);
+                    boundStatement.setInt(1, j);
+                    boundStatement.setInt(2, TransferCommon.INITIAL_BALANCE);
+                    sqlSession.execute(boundStatement);
                   }
                 }
 


### PR DESCRIPTION
## Description

This PR updates `TransferProcessor`, `TransferPreparer`, and `TransferWithTwoPhaseCommitTransactionProcessor` to use the new `PreparedStatement` API introduced in https://github.com/scalar-labs/scalardb-sql/pull/953.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb-sql/pull/953

## Changes made

- Updated `TransferProcessor`, `TransferPreparer`, and `TransferWithTwoPhaseCommitTransactionProcessor` to use the new `PreparedStatement` API
- Replaced `PreparedStatement.set()` / `execute()` / `clearParameters()` with `PreparedStatement.bind()` to create `BoundStatement`, `BoundStatement.setInt()` for parameter binding, and `SqlSession.execute(boundStatement)` for execution

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A