### PR TITLE
Adapt to void return type change of SqlSession's begin() method

### DIFF
--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/sql/TransferWithTwoPhaseCommitTransactionProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/sql/TransferWithTwoPhaseCommitTransactionProcessor.java
@@ -87,7 +87,11 @@ public class TransferWithTwoPhaseCommitTransactionProcessor extends TimeBasedPro
             + "=?";
 
     try {
-      String transactionId = sqlSession1.begin();
+      sqlSession1.begin();
+      String transactionId =
+          sqlSession1
+              .getTransactionId()
+              .orElseThrow(() -> new IllegalStateException("Transaction ID is not available"));
       sqlSession2.join(transactionId);
 
       BoundStatement boundStatement = sqlSession1.prepareStatement(SELECT_QUERY).bind();


### PR DESCRIPTION
## Description

This PR updates `TransferWithTwoPhaseCommitTransactionProcessor` to dapt to the `SqlSession`'s `begin()` method return type change from `String` to `void` introduced in https://github.com/scalar-labs/scalardb-sql/pull/976.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb-sql/pull/976

## Changes made

- Updated `TransferWithTwoPhaseCommitTransactionProcessor` to call `begin()` and then `getTransactionId()` separately, instead of capturing the return value of `begin()`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
