### PR TITLE
Fix write skew test

### DIFF
--- a/.github/workflows/daily-db-verification.yml
+++ b/.github/workflows/daily-db-verification.yml
@@ -17,9 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         test:
-          - name: phantom-write
-            schema: schema/tx_sensor.cql
-            config: phantom-write-config.toml
           - name: write-skew
             schema: schema/tx_transfer.cql
             config: write-skew-config.toml
@@ -125,7 +122,7 @@ jobs:
 
   notify-slack:
     name: Notify Slack
-    if: always()
+    if: always() && github.event_name != 'workflow_dispatch'
     needs: verify
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/daily-db-verification.yml
+++ b/.github/workflows/daily-db-verification.yml
@@ -17,6 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         test:
+          - name: phantom-write
+            schema: schema/tx_sensor.cql
+            config: phantom-write-config.toml
           - name: write-skew
             schema: schema/tx_transfer.cql
             config: write-skew-config.toml

--- a/scalardb-test/src/main/java/kelpie/scalardb/Common.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/Common.java
@@ -92,7 +92,7 @@ public class Common {
     props.setProperty("scalar.db.storage", storage);
     props.setProperty("scalar.db.transaction_manager", transactionManager);
     props.setProperty("scalar.db.consensus_commit.isolation_level", isolationLevel);
-    logWarn("ISOLATION_LEVEL: " + isolationLevel);
+    logger.warn("ISOLATION_LEVEL: {}", isolationLevel);
 
     return new DatabaseConfig(props);
   }

--- a/scalardb-test/src/main/java/kelpie/scalardb/Common.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/Common.java
@@ -92,7 +92,6 @@ public class Common {
     props.setProperty("scalar.db.storage", storage);
     props.setProperty("scalar.db.transaction_manager", transactionManager);
     props.setProperty("scalar.db.consensus_commit.isolation_level", isolationLevel);
-
     return new DatabaseConfig(props);
   }
 

--- a/scalardb-test/src/main/java/kelpie/scalardb/Common.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/Common.java
@@ -92,7 +92,6 @@ public class Common {
     props.setProperty("scalar.db.storage", storage);
     props.setProperty("scalar.db.transaction_manager", transactionManager);
     props.setProperty("scalar.db.consensus_commit.isolation_level", isolationLevel);
-    logger.warn("ISOLATION_LEVEL: {}", isolationLevel);
 
     return new DatabaseConfig(props);
   }

--- a/scalardb-test/src/main/java/kelpie/scalardb/Common.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/Common.java
@@ -92,6 +92,8 @@ public class Common {
     props.setProperty("scalar.db.storage", storage);
     props.setProperty("scalar.db.transaction_manager", transactionManager);
     props.setProperty("scalar.db.consensus_commit.isolation_level", isolationLevel);
+    logWarn("ISOLATION_LEVEL: " + isolationLevel);
+
     return new DatabaseConfig(props);
   }
 

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
@@ -100,6 +100,11 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
       Get get = TransferCommon.prepareGet(fromId, i);
       Optional<Result> result = transaction.get(get);
       int balance = TransferCommon.getBalanceFromResult(result.get());
+      if (balance == 0) {
+        logWarn("UNEXPECTED BALANCE: " + fromId + "," + fromType + " Balance: " + balance);
+        logWarn("Retrieved result: " + result);
+      }
+
       if (i == fromType) {
         fromBalance = balance;
       }

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
@@ -175,11 +175,13 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
     }
 
     if (e instanceof UnknownTransactionStatusException) {
-      if (fromId != toId) {
-        unknownTransactions.put(txId, Arrays.asList(fromId, fromType, toId, toType));
-      }
       logWarn("the status of the transaction is unknown: " + txId, e);
-      logTxInfo("unknown", txId, fromId, fromType, toId, toType, amount);
+      if (fromId == toId) {
+        logInfo("Checking the total balance of " + fromId + " failed (unknown status)");
+      } else {
+        unknownTransactions.put(txId, Arrays.asList(fromId, fromType, toId, toType));
+        logTxInfo("unknown", txId, fromId, fromType, toId, toType, amount);
+      }
     } else {
       logWarn(txId + " failed", e);
       if (fromId == toId) {

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
@@ -57,7 +57,11 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
     logStart(txId, fromId, fromType, toId, toType, amount);
 
     try {
-      transfer(transaction, fromId, fromType, toId, toType, amount);
+      if (fromId != toId) {
+        transfer(transaction, fromId, fromType, toId, toType, amount);
+      } else {
+        checkSkew(transaction, fromId);
+      }
     } catch (Exception e) {
       logFailure(txId, fromId, fromType, toId, toType, amount, e);
       throw e;
@@ -95,8 +99,8 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
       throws TransactionException {
     int fromBalance = 0;
     int totalBalance = 0;
-		int balance0 = 0;
-		int balance1 = 0;
+    int balance0 = 0;
+    int balance1 = 0;
 
     for (int i = 0; i < TransferCommon.NUM_TYPES; i++) {
       Get get = TransferCommon.prepareGet(fromId, i);
@@ -115,13 +119,6 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
       totalBalance += balance;
     }
 
-    if (totalBalance < 0) {
-      logWarn("UNEXPECTED TOTAL BALANCE: " + fromId + " Balance: " + totalBalance);
-      logWarn("UNEXPECTED BALANCE: " + fromId + ",0 Balance: " + balance0);
-      logWarn("UNEXPECTED BALANCE: " + fromId + ",1 Balance: " + balance1);
-      throw new ProcessFatalException("The total balance of " + fromId + " is negative");
-    }
-
     if ((totalBalance - amount) < 0) {
       throw new ProcessException("the account doesn't have the enough balance");
     }
@@ -138,15 +135,44 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
     transaction.commit();
   }
 
+  private void checkSkew(DistributedTransaction transaction, int accountId)
+      throws TransactionException {
+    int totalBalance = 0;
+
+    for (int i = 0; i < TransferCommon.NUM_TYPES; i++) {
+      Get get = TransferCommon.prepareGet(accountId, i);
+      Optional<Result> result = transaction.get(get);
+      int balance = TransferCommon.getBalanceFromResult(result.get());
+
+      totalBalance += balance;
+    }
+
+    transaction.commit();
+
+    // check only if no other transaction updates these balances
+    if (totalBalance < 0) {
+      throw new ProcessFatalException(
+          "The total balance of " + accountId + " is negative: " + totalBalance);
+    }
+  }
+
   private void logStart(String txId, int fromId, int fromType, int toId, int toType, int amount) {
     if (isVerification.get()) {
-      logTxInfo("started", txId, fromId, fromType, toId, toType, amount);
+      if (fromId == toId) {
+        logInfo("started to check skew - id: " + txId + " account ID: " + fromId);
+      } else {
+        logTxInfo("started", txId, fromId, fromType, toId, toType, amount);
+      }
     }
   }
 
   private void logSuccess(String txId, int fromId, int fromType, int toId, int toType, int amount) {
     if (isVerification.get()) {
-      logTxInfo("succeeded", txId, fromId, fromType, toId, toType, amount);
+      if (fromId == toId) {
+        logInfo("The total balance of " + fromId + " is larger than or equal to zero");
+      } else {
+        logTxInfo("succeeded", txId, fromId, fromType, toId, toType, amount);
+      }
       numUpdates.getAndAdd(2);
     }
   }

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
@@ -107,6 +107,7 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
       } else {
         balance1 = balance;
       }
+      logWarn("DEBUGGING BALANCE: " + fromId + "," + i + " Balance: " + balance);
 
       if (i == fromType) {
         fromBalance = balance;

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
@@ -67,6 +67,9 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
     logInfo("started to check skew - id: " + checkTxId + " account ID: " + fromId);
     try {
       checkSkew(checkTx, fromId);
+    } catch (ProcessFatalException e) {
+      // throw the fatal exception without abort since write skew happened
+      throw e;
     } catch (Exception e) {
       logWarn("checking the total balance of " + fromId + " failed - id: " + checkTxId, e);
       checkTx.abort();

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
@@ -184,12 +184,18 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
     }
 
     if (e instanceof UnknownTransactionStatusException) {
-      unknownTransactions.put(txId, Arrays.asList(fromId, fromType, toId, toType));
+      if (fromId != toId) {
+        unknownTransactions.put(txId, Arrays.asList(fromId, fromType, toId, toType));
+      }
       logWarn("the status of the transaction is unknown: " + txId, e);
       logTxInfo("unknown", txId, fromId, fromType, toId, toType, amount);
     } else {
       logWarn(txId + " failed", e);
-      logTxInfo("failed", txId, fromId, fromType, toId, toType, amount);
+      if (fromId == toId) {
+        logInfo("Checking the total balance of " + fromId + " failed");
+      } else {
+        logTxInfo("failed", txId, fromId, fromType, toId, toType, amount);
+      }
     }
   }
 

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
@@ -172,8 +172,8 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
         logInfo("The total balance of " + fromId + " is larger than or equal to zero");
       } else {
         logTxInfo("succeeded", txId, fromId, fromType, toId, toType, amount);
+        numUpdates.getAndAdd(2);
       }
-      numUpdates.getAndAdd(2);
     }
   }
 

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
@@ -95,14 +95,17 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
       throws TransactionException {
     int fromBalance = 0;
     int totalBalance = 0;
+		int balance0 = 0;
+		int balance1 = 0;
 
     for (int i = 0; i < TransferCommon.NUM_TYPES; i++) {
       Get get = TransferCommon.prepareGet(fromId, i);
       Optional<Result> result = transaction.get(get);
       int balance = TransferCommon.getBalanceFromResult(result.get());
-      if (balance == 0) {
-        logWarn("UNEXPECTED BALANCE: " + fromId + "," + fromType + " Balance: " + balance);
-        logWarn("Retrieved result: " + result);
+      if (i == 0) {
+        balance0 = balance;
+      } else {
+        balance1 = balance;
       }
 
       if (i == fromType) {
@@ -112,6 +115,9 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
     }
 
     if (totalBalance < 0) {
+      logWarn("UNEXPECTED TOTAL BALANCE: " + fromId + " Balance: " + totalBalance);
+      logWarn("UNEXPECTED BALANCE: " + fromId + ",0 Balance: " + balance0);
+      logWarn("UNEXPECTED BALANCE: " + fromId + ",1 Balance: " + balance1);
       throw new ProcessFatalException("The total balance of " + fromId + " is negative");
     }
 

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.json.Json;
 import javax.json.JsonObjectBuilder;
@@ -26,7 +25,6 @@ import kelpie.scalardb.Common;
 public class WriteSkewTransferProcessor extends TimeBasedProcessor {
   private final DistributedTransactionManager manager;
   private final int numAccounts;
-  private final AtomicBoolean isVerification;
   private final AtomicInteger numUpdates = new AtomicInteger(0);
 
   // for verification
@@ -37,8 +35,6 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
     this.manager = Common.getTransactionManager(config);
 
     this.numAccounts = (int) config.getUserLong("test_config", "num_accounts");
-    this.isVerification =
-        new AtomicBoolean(config.getUserBoolean("test_config", "is_verification", false));
   }
 
   @Override
@@ -60,18 +56,20 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
       transfer(transaction, fromId, fromType, toId, toType, amount);
     } catch (Exception e) {
       logFailure(txId, fromId, fromType, toId, toType, amount, e);
+      transaction.abort();
       throw e;
     }
     logSuccess(txId, fromId, fromType, toId, toType, amount);
 
     // check fromId's balances
     DistributedTransaction checkTx = manager.start();
-    String checkTxId = transaction.getId();
+    String checkTxId = checkTx.getId();
     logInfo("started to check skew - id: " + checkTxId + " account ID: " + fromId);
     try {
       checkSkew(checkTx, fromId);
     } catch (Exception e) {
       logWarn("checking the total balance of " + fromId + " failed - id: " + checkTxId, e);
+      checkTx.abort();
       throw e;
     }
     logInfo("The total balance of " + fromId + " is larger than or equal to zero");
@@ -148,7 +146,7 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
 
     transaction.commit();
 
-    // check only if no other transaction updates these balances
+    // check if no other transaction updates these balances
     if (totalBalance < 0) {
       throw new ProcessFatalException(
           "The total balance of " + accountId + " is negative: " + totalBalance);
@@ -156,24 +154,16 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
   }
 
   private void logStart(String txId, int fromId, int fromType, int toId, int toType, int amount) {
-    if (isVerification.get()) {
-      logTxInfo("started", txId, fromId, fromType, toId, toType, amount);
-    }
+    logTxInfo("started", txId, fromId, fromType, toId, toType, amount);
   }
 
   private void logSuccess(String txId, int fromId, int fromType, int toId, int toType, int amount) {
-    if (isVerification.get()) {
-      logTxInfo("succeeded", txId, fromId, fromType, toId, toType, amount);
-      numUpdates.getAndAdd(2);
-    }
+    logTxInfo("succeeded", txId, fromId, fromType, toId, toType, amount);
+    numUpdates.getAndAdd(2);
   }
 
   private void logFailure(
       String txId, int fromId, int fromType, int toId, int toType, int amount, Throwable e) {
-    if (!isVerification.get()) {
-      return;
-    }
-
     if (e instanceof UnknownTransactionStatusException) {
       unknownTransactions.put(txId, Arrays.asList(fromId, fromType, toId, toType));
       logWarn("the status of the transaction is unknown: " + txId, e);

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
@@ -57,16 +57,24 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
     logStart(txId, fromId, fromType, toId, toType, amount);
 
     try {
-      if (fromId != toId) {
-        transfer(transaction, fromId, fromType, toId, toType, amount);
-      } else {
-        checkSkew(transaction, fromId);
-      }
+      transfer(transaction, fromId, fromType, toId, toType, amount);
     } catch (Exception e) {
       logFailure(txId, fromId, fromType, toId, toType, amount, e);
       throw e;
     }
     logSuccess(txId, fromId, fromType, toId, toType, amount);
+
+    // check fromId's balances
+    DistributedTransaction transaction = manager.start();
+    String txId = transaction.getId();
+    logInfo("started to check skew - id: " + txId + " account ID: " + fromId);
+    try {
+      checkSkew(transaction, fromId);
+    } catch (Exception e) {
+      logWarn("checking the total balance of " + fromId + " failed - id: " + tx_id, e);
+      throw e;
+    }
+    logInfo("The total balance of " + fromId + " is larger than or equal to zero");
   }
 
   @Override
@@ -149,22 +157,14 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
 
   private void logStart(String txId, int fromId, int fromType, int toId, int toType, int amount) {
     if (isVerification.get()) {
-      if (fromId == toId) {
-        logInfo("started to check skew - id: " + txId + " account ID: " + fromId);
-      } else {
-        logTxInfo("started", txId, fromId, fromType, toId, toType, amount);
-      }
+      logTxInfo("started", txId, fromId, fromType, toId, toType, amount);
     }
   }
 
   private void logSuccess(String txId, int fromId, int fromType, int toId, int toType, int amount) {
     if (isVerification.get()) {
-      if (fromId == toId) {
-        logInfo("The total balance of " + fromId + " is larger than or equal to zero");
-      } else {
-        logTxInfo("succeeded", txId, fromId, fromType, toId, toType, amount);
-        numUpdates.getAndAdd(2);
-      }
+      logTxInfo("succeeded", txId, fromId, fromType, toId, toType, amount);
+      numUpdates.getAndAdd(2);
     }
   }
 
@@ -175,20 +175,12 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
     }
 
     if (e instanceof UnknownTransactionStatusException) {
+      unknownTransactions.put(txId, Arrays.asList(fromId, fromType, toId, toType));
       logWarn("the status of the transaction is unknown: " + txId, e);
-      if (fromId == toId) {
-        logInfo("Checking the total balance of " + fromId + " failed (unknown status)");
-      } else {
-        unknownTransactions.put(txId, Arrays.asList(fromId, fromType, toId, toType));
-        logTxInfo("unknown", txId, fromId, fromType, toId, toType, amount);
-      }
+      logTxInfo("unknown", txId, fromId, fromType, toId, toType, amount);
     } else {
       logWarn(txId + " failed", e);
-      if (fromId == toId) {
-        logInfo("Checking the total balance of " + fromId + " failed");
-      } else {
-        logTxInfo("failed", txId, fromId, fromType, toId, toType, amount);
-      }
+      logTxInfo("failed", txId, fromId, fromType, toId, toType, amount);
     }
   }
 

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
@@ -65,13 +65,13 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
     logSuccess(txId, fromId, fromType, toId, toType, amount);
 
     // check fromId's balances
-    DistributedTransaction transaction = manager.start();
-    String txId = transaction.getId();
-    logInfo("started to check skew - id: " + txId + " account ID: " + fromId);
+    DistributedTransaction checkTx = manager.start();
+    String checkTxId = transaction.getId();
+    logInfo("started to check skew - id: " + checkTxId + " account ID: " + fromId);
     try {
-      checkSkew(transaction, fromId);
+      checkSkew(checkTx, fromId);
     } catch (Exception e) {
-      logWarn("checking the total balance of " + fromId + " failed - id: " + tx_id, e);
+      logWarn("checking the total balance of " + fromId + " failed - id: " + checkTxId, e);
       throw e;
     }
     logInfo("The total balance of " + fromId + " is larger than or equal to zero");

--- a/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
+++ b/scalardb-test/src/main/java/kelpie/scalardb/transfer/WriteSkewTransferProcessor.java
@@ -99,20 +99,11 @@ public class WriteSkewTransferProcessor extends TimeBasedProcessor {
       throws TransactionException {
     int fromBalance = 0;
     int totalBalance = 0;
-    int balance0 = 0;
-    int balance1 = 0;
 
     for (int i = 0; i < TransferCommon.NUM_TYPES; i++) {
       Get get = TransferCommon.prepareGet(fromId, i);
       Optional<Result> result = transaction.get(get);
       int balance = TransferCommon.getBalanceFromResult(result.get());
-      if (i == 0) {
-        balance0 = balance;
-      } else {
-        balance1 = balance;
-      }
-      logWarn("DEBUGGING BALANCE: " + fromId + "," + i + " Balance: " + balance);
-
       if (i == fromType) {
         fromBalance = balance;
       }


### PR DESCRIPTION
## Description
The test detected a false-positive skew because the balances were not at the same time. Another balance could be updated by other transactions.
Adding read-only transactions to check the skew will fix this issue.

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made
- Add read-only transaction ~~when fromId == toId (Transfers between the same ID couldn't cause any skew in this test)~~
- Check if the total balance is positive when the read-only transaction is committed

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
