### PR TITLE
Fix DL benchmark workflow

### DIFF
--- a/.github/workflows/daily-dl-benchmark.yml
+++ b/.github/workflows/daily-dl-benchmark.yml
@@ -76,8 +76,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Work around ledger config path in scalardl-samples
-        working-directory: scalardl-samples/mysql
+      - name: Work around scalardl-samples ledger config
+        working-directory: scalardl-samples/postgres
         run: |
           # The sample compose mounts the (already-complete) ledger.properties
           # to /scalar/ledger/ledger.properties.tmpl, expecting the image to
@@ -87,8 +87,26 @@ jobs:
           sed -i 's#ledger\.properties\.tmpl#ledger.properties#' \
             docker-compose-ledger.yml
 
+          # Disable the JVM SecurityManager (contract sandbox). With a JDBC
+          # backend, ScalarDL's contract ProtectionDomain
+          # (LedgerModule.getProtectionDomain) does not grant the permissions
+          # the JDBC driver + HikariCP need at request time (PropertyPermission
+          # "socksProxyHost" "read", SQLPermission "setNetworkTimeout",
+          # SocketPermission to the DB host), so DB access during contract
+          # execution fails with AccessControlException. The launcher runs
+          # `java $DEFAULT_JVM_OPTS $JAVA_OPTS $SCALAR_LEDGER_OPTS`, where
+          # DEFAULT_JVM_OPTS hardcodes a bare `-Djava.security.manager`;
+          # appending `-Djava.security.manager=allow` via SCALAR_LEDGER_OPTS
+          # wins (last value) so no SM is installed.
+          sed -i '/^  scalardl-ledger:$/a\    environment:\n      SCALAR_LEDGER_OPTS: "-Djava.security.manager=allow"' \
+            docker-compose-ledger.yml
+
+          echo "::group::Patched docker-compose-ledger.yml"
+          cat docker-compose-ledger.yml
+          echo "::endgroup::"
+
       - name: Start ScalarDL ledger
-        working-directory: scalardl-samples/mysql
+        working-directory: scalardl-samples/postgres
         run: |
           SCALARDL_VERSION="${SCALARDL_VERSION}" \
             docker compose -f docker-compose-ledger.yml up -d --wait
@@ -323,10 +341,10 @@ jobs:
 
       - name: Stop ScalarDL ledger
         if: always()
-        working-directory: scalardl-samples/mysql
+        working-directory: scalardl-samples/postgres
         run: |
           mkdir -p "${{ github.workspace }}/scalardl-test/results/docker-logs"
-          for svc in mysql scalardl-ledger ledger-envoy; do
+          for svc in postgres scalardl-ledger ledger-envoy; do
             docker compose -f docker-compose-ledger.yml logs --no-color "$svc" \
               > "${{ github.workspace }}/scalardl-test/results/docker-logs/${svc}.log" 2>&1 || true
           done

--- a/.github/workflows/daily-dl-benchmark.yml
+++ b/.github/workflows/daily-dl-benchmark.yml
@@ -62,13 +62,15 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
+        with:
+          add-job-summary: never
 
       - name: Build shadow jar
         working-directory: scalardl-test
         run: ./gradlew shadowJar
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/daily-dl-benchmark.yml
+++ b/.github/workflows/daily-dl-benchmark.yml
@@ -74,6 +74,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Work around ledger config path in scalardl-samples
+        working-directory: scalardl-samples/postgres
+        run: |
+          # The sample compose mounts the (already-complete) ledger.properties
+          # to /scalar/ledger/ledger.properties.tmpl, expecting the image to
+          # render the template at startup. The 4.0.0-SNAPSHOT ledger image
+          # reads /scalar/ledger/ledger.properties directly and never renders
+          # the .tmpl, so mount it to the real path instead.
+          sed -i 's#ledger\.properties\.tmpl#ledger.properties#' \
+            docker-compose-ledger.yml
+
       - name: Start ScalarDL ledger
         working-directory: scalardl-samples/postgres
         run: |

--- a/.github/workflows/daily-dl-benchmark.yml
+++ b/.github/workflows/daily-dl-benchmark.yml
@@ -77,7 +77,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Work around ledger config path in scalardl-samples
-        working-directory: scalardl-samples/postgres
+        working-directory: scalardl-samples/mysql
         run: |
           # The sample compose mounts the (already-complete) ledger.properties
           # to /scalar/ledger/ledger.properties.tmpl, expecting the image to
@@ -88,7 +88,7 @@ jobs:
             docker-compose-ledger.yml
 
       - name: Start ScalarDL ledger
-        working-directory: scalardl-samples/postgres
+        working-directory: scalardl-samples/mysql
         run: |
           SCALARDL_VERSION="${SCALARDL_VERSION}" \
             docker compose -f docker-compose-ledger.yml up -d --wait
@@ -317,10 +317,10 @@ jobs:
 
       - name: Stop ScalarDL ledger
         if: always()
-        working-directory: scalardl-samples/postgres
+        working-directory: scalardl-samples/mysql
         run: |
           mkdir -p "${{ github.workspace }}/scalardl-test/results/docker-logs"
-          for svc in postgres scalardl-ledger ledger-envoy; do
+          for svc in mysql scalardl-ledger ledger-envoy; do
             docker compose -f docker-compose-ledger.yml logs --no-color "$svc" \
               > "${{ github.workspace }}/scalardl-test/results/docker-logs/${svc}.log" 2>&1 || true
           done

--- a/.github/workflows/daily-dl-benchmark.yml
+++ b/.github/workflows/daily-dl-benchmark.yml
@@ -101,10 +101,6 @@ jobs:
           sed -i '/^  scalardl-ledger:$/a\    environment:\n      SCALAR_LEDGER_OPTS: "-Djava.security.manager=allow"' \
             docker-compose-ledger.yml
 
-          echo "::group::Patched docker-compose-ledger.yml"
-          cat docker-compose-ledger.yml
-          echo "::endgroup::"
-
       - name: Start ScalarDL ledger
         working-directory: scalardl-samples/postgres
         run: |

--- a/.github/workflows/daily-dl-benchmark.yml
+++ b/.github/workflows/daily-dl-benchmark.yml
@@ -132,7 +132,13 @@ jobs:
 
             echo "::group::Run kelpie (concurrency=${c})"
             LOG="scalardl-test/results/run-c${c}.log"
-            if "$KELPIE_BIN" --config scalardl-test/benchmark-config.toml 2>&1 | tee "$LOG"; then
+            if [[ "$c" != "1" ]]; then
+              ARGS="--config scalardl-test/benchmark-config.toml --except-pre"
+            else
+              ARGS="--config scalardl-test/benchmark-config.toml"
+            fi
+
+            if "$KELPIE_BIN" ${ARGS} 2>&1 | tee "$LOG"; then
               echo "Run for concurrency=${c} succeeded."
             else
               echo "Run for concurrency=${c} FAILED with exit ${PIPESTATUS[0]}." >&2


### PR DESCRIPTION
## Description
Fix the daily DL benchmark workflow.
Ledger container tried to load `ledger.properties`, but the file was `ledger.properties.tmpl`.
Workaround to the correct path.
The preparation in the test failed after concurrency=1.
~~The latest DL ledger didn't work with Postgres on the scalardl-samples Docker environment.~~ -> workaround the security policy issue

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made
- Replace the ledger.properties
- Preparation is executed in only concurrency=1
- ~~Use MySQL~~ Workaround the security policy issue

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
