### PR TITLE
Add tx_write_set column to coordinator schema

### DIFF
--- a/scalardb-test/schema/tx_sensor.cql
+++ b/scalardb-test/schema/tx_sensor.cql
@@ -28,6 +28,7 @@ CREATE TABLE IF NOT EXISTS coordinator.state (
     tx_child_ids text,
     tx_state int,
     tx_created_at bigint,
+    tx_write_set blob,
     PRIMARY KEY (tx_id)
 );
 

--- a/scalardb-test/schema/tx_transfer.cql
+++ b/scalardb-test/schema/tx_transfer.cql
@@ -28,6 +28,7 @@ CREATE TABLE IF NOT EXISTS coordinator.state (
     tx_child_ids text,
     tx_state int,
     tx_created_at bigint,
+    tx_write_set blob,
     PRIMARY KEY (tx_id)
 );
 


### PR DESCRIPTION
## Description

I have added the `tx_write_set` column to coordinator  table schma transfer and sensor schema files.
I have added this change to fix issue which causes the scalardb benchmark test to fail (ticket https://scalar-labs.atlassian.net/browse/DLT-18723) based on comment by Suzuki-san (ref https://scalar-labs.atlassian.net/browse/DLT-18723?focusedCommentId=37285).

## Related issues and/or PRs

NA

## Changes made

* Added the `tx_write_set` column to coordinator  table schma transfer and sensor schema files

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
